### PR TITLE
[Setting] PR의 reviewer를 자동 할당을 위해 auto-assign을 설정합니다.

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,20 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: false
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers: 
+  - compuTasha
+  - GODNOEL
+  - Rookie0031
+  - ccdkk
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it 
+skipKeywords:
+  - wip
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 0


### PR DESCRIPTION
## 관련 이슈

- #7 

## 배경

PR(Pull Request)할 때 자동으로 검토자를(assigner) 배정해주는 auto-assign을 설정합니다.

## 작업 내용

Github app인  auto-assign 설치 후 `.github/auto_assign.yml` 파일 추가 했습니다.

## 리뷰 노트

`.github/auto-assign.yml` 파일에서 본인의 유저명을 확인해주세요!

