### PR TITLE
[Design] Extension Color 값들을 추가합니다.

### DIFF
--- a/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
@@ -43,15 +43,15 @@ extension UIColor {
     
     // MARK: - bule
     
-    static var blue01: UIColor {
+    static var bule01: UIColor {
         return UIColor(hex: "#4A87FF")
     }
     
-    static var blue02: UIColor {
+    static var bule02: UIColor {
         return UIColor(hex: "#6D7EF7")
     }
     
-    static var blue03: UIColor {
+    static var bule03: UIColor {
         return UIColor(hex: "#CAD2FF")
     }
     

--- a/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
@@ -9,10 +9,67 @@ import UIKit
 
 extension UIColor {
     
-    static var exampleGray: UIColor {
-        return UIColor(hex: "#f3f3f3")
+    // MARK: - background
+    
+    static var dark01: UIColor {
+        return UIColor(hex: "#17171B")
     }
     
+    static var dark02: UIColor {
+        return UIColor(hex: "#202026")
+    }
+    
+    static var dark03: UIColor {
+        return UIColor(hex: "#2E2E36")
+    }
+    
+    static var dark04: UIColor {
+        return UIColor(hex: "#43434D")
+    }
+    
+    // MARK: - purple
+    
+    static var activeGradationPurple: UIColor {
+        return UIColor(hex: "#411A59")
+    }
+    
+    static var mainPurple: UIColor {
+        return UIColor(hex: "#AF4DEC")
+    }
+    
+    static var lightPurple: UIColor {
+        return UIColor(hex: "#ECCDFF")
+    }
+    
+    // MARK: - bule
+    
+    static var bule01: UIColor {
+        return UIColor(hex: "#4A87FF")
+    }
+    
+    static var bule02: UIColor {
+        return UIColor(hex: "#6D7EF7")
+    }
+    
+    static var bule03: UIColor {
+        return UIColor(hex: "#CAD2FF")
+    }
+    
+    // MARK: - gray
+    
+    static var gray01: UIColor {
+        return UIColor(hex: "#5F5F5F")
+    }
+    
+    static var gray02: UIColor {
+        return UIColor(hex: "#AFAFAF")
+    }
+    
+    // MARK: - etc
+    
+    static var warningRed: UIColor {
+        return UIColor(hex: "#CA0000")
+    }
 }
 
 extension UIColor {

--- a/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
@@ -43,15 +43,15 @@ extension UIColor {
     
     // MARK: - bule
     
-    static var bule01: UIColor {
+    static var blue01: UIColor {
         return UIColor(hex: "#4A87FF")
     }
     
-    static var bule02: UIColor {
+    static var blue02: UIColor {
         return UIColor(hex: "#6D7EF7")
     }
     
-    static var bule03: UIColor {
+    static var blue03: UIColor {
         return UIColor(hex: "#CAD2FF")
     }
     

--- a/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/UIColor+Extension.swift
@@ -41,7 +41,7 @@ extension UIColor {
         return UIColor(hex: "#ECCDFF")
     }
     
-    // MARK: - bule
+    // MARK: - blue
     
     static var blue01: UIColor {
         return UIColor(hex: "#4A87FF")


### PR DESCRIPTION
## 관련 이슈

- #25 

<br/>

## 배경

프로젝트에서 사용된 색상을 사용하기 편하게 Extension으로 추가했습니다.

<br/>

## 작업 내용

기존의 UIColor+Extension.swift에 프로젝트에서 사용된 색상을 추가했습니다.
경로 : Global >  Extensions >  UIColor+Extension.swift
노션에서 색상들이 사용된 곳을 확인 할 수 있습니다.
https://fascinated-neem-285.notion.site/84da850a983848e783fe66e2bfda103e
<br/>
![noname](https://user-images.githubusercontent.com/103012104/213683076-7934b80c-492c-44ba-8f91-c3208031961d.png)

<br/>

## 리뷰 노트

- 색상명이 직관적인가?

<br/>

## 테스트 방법

👉 View에 UIColor 값이 들어가는 곳에 `.색상이름`을 입력합니다.

```
//사용 예시
override func viewDidLoad() {
        super.viewDidLoad()
        view.backgroundColor = .dark01
    }
```
