### PR TITLE
[Fix] 지도가 계속해서 현재 위치로 이동하는 것을 막습니다.

### DIFF
--- a/GetARock/GetARock/Screens/Maps/MainMapViewController.swift
+++ b/GetARock/GetARock/Screens/Maps/MainMapViewController.swift
@@ -124,13 +124,16 @@ final class MainMapViewController: UIViewController {
         self.locationManager.requestWhenInUseAuthorization()
     }
     
-    private func moveLocation(to coordinate: CLLocationCoordinate2D?) {
-        guard let coordinate else { return }
-        self.currentCoordinate = coordinate
+    private func moveMap() {
         camera = GMSCameraPosition.camera(withLatitude: currentCoordinate.latitude,
                                           longitude: currentCoordinate.longitude,
                                           zoom: zoomInRange)
         mapView.camera = camera
+    }
+    
+    private func moveMyLocationMarker(to coordinate: CLLocationCoordinate2D?) {
+        guard let coordinate else { return }
+        self.currentCoordinate = coordinate
         myLocationMarker.position = CLLocationCoordinate2D(latitude: currentCoordinate.latitude,
                                                            longitude: currentCoordinate.longitude)
         myLocationMarker.map = mapView
@@ -160,7 +163,7 @@ extension MainMapViewController: CLLocationManagerDelegate {
     
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let currentLocation = locations.first else { return }
-        moveLocation(to: currentLocation.coordinate)
+        moveMyLocationMarker(to: currentLocation.coordinate)
         
         CLGeocoder().reverseGeocodeLocation(
             currentLocation,

--- a/GetARock/GetARock/Screens/Maps/MainMapViewController.swift
+++ b/GetARock/GetARock/Screens/Maps/MainMapViewController.swift
@@ -92,6 +92,11 @@ final class MainMapViewController: UIViewController {
         self.setLocationManager()
     }
     
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        moveMap()
+    }
+
     // MARK: - Method
     
     private func setupLayout() {


### PR DESCRIPTION

<!-- 불필요한 항목은 삭제해주세요 -->


## 관련 이슈
- close #46 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
기존의 코드는 `moveLocation(to:)` 메소드에 **_지도 시점 이동_** + **_현재 위치 마커 이동_** 코드를 둘 다 구현해두고,
`locationManager(_:didUpdateLocations:)` 에서 위치가 변경될때마다 `moveLocation(to:)`를 호출하고 있습니다.

이렇게 구현하니 지도를 이동해서 다른 장소를 보고 있더라도
위치가 업데이트됨에 따라 다시 현재 위치로 지도의 시점이 이동하는 문제가 생겼습니다..

이를 해결하고자 `moveLocation(to:)`을 **_지도 시점 이동_** ,  **_현재 위치 마커 이동_** 2개의 메소드로 구분해서 구현했습니다.
<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
- `moveMap()` : 지도의 **시점**을 이동하는 메소드, 추후 현재 위치로 이동 버튼을 클릭하면 호출할 예정 

- `moveMylocationMarker(to:)` : 현재 내 위치를 나타내는 **마커**를 이동하는 메소드
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->


## 테스트 방법
`SceneDelegate`에서 아래와 같이 수정해주세요.

```swift
window.rootViewController = MainMapViewController()
```

<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->


<!--## 해당 PR 확정 사항-->

<!-- 해당 PR 리뷰 과정에서 논의된 확정 사항을 develop 브랜치에 머지하기 전 정리합니다. -->
