### PR TITLE
[Design] 기본 컴포넌트인 BasicTextView를 구현합니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -13,9 +13,11 @@
 		7BEA1875297AA10800A40488 /* UIFont+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BEA1874297AA10800A40488 /* UIFont+Extension.swift */; };
 		943928805D82F089F179FC19 /* Pods_GetARock.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B7323F5DF501B54C2FAD4892 /* Pods_GetARock.framework */; };
 		9A29E6E6297E21C500D4A433 /* UITextField+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A29E6E5297E21C500D4A433 /* UITextField+Extension.swift */; };
-		9A29E6E8297E223A00D4A433 /* TextFieldSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A29E6E7297E223A00D4A433 /* TextFieldSize.swift */; };
+		9A29E6E8297E223A00D4A433 /* BasicComponentSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A29E6E7297E223A00D4A433 /* BasicComponentSize.swift */; };
 		9A29E6EA297E233900D4A433 /* BasicTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A29E6E9297E233900D4A433 /* BasicTextField.swift */; };
 		A769E177D6AA52251CAA0997 /* Pods_GetARockTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F817079C25E9C663E82B27 /* Pods_GetARockTests.framework */; };
+		A96B8A0B2981706C00905BC9 /* BasicTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0A2981706C00905BC9 /* BasicTextView.swift */; };
+		A96B8A0D2981714800905BC9 /* BasicLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0C2981714800905BC9 /* BasicLabel.swift */; };
 		B8468F5F29797E7D00A9E77E /* MapsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = B8468F5E29797E7D00A9E77E /* MapsInfo.plist */; };
 		B8468F6129797EFE00A9E77E /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8468F6029797EFE00A9E77E /* Bundle+Extension.swift */; };
 		B8468F66297AD7CB00A9E77E /* MainMapViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8468F65297AD7CB00A9E77E /* MainMapViewController.swift */; };
@@ -63,8 +65,10 @@
 		7BEA1874297AA10800A40488 /* UIFont+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+Extension.swift"; sourceTree = "<group>"; };
 		9519F0525025E6972410CA40 /* Pods-GetARock-GetARockUITests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetARock-GetARockUITests.debug.xcconfig"; path = "Target Support Files/Pods-GetARock-GetARockUITests/Pods-GetARock-GetARockUITests.debug.xcconfig"; sourceTree = "<group>"; };
 		9A29E6E5297E21C500D4A433 /* UITextField+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+Extension.swift"; sourceTree = "<group>"; };
-		9A29E6E7297E223A00D4A433 /* TextFieldSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldSize.swift; sourceTree = "<group>"; };
+		9A29E6E7297E223A00D4A433 /* BasicComponentSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicComponentSize.swift; sourceTree = "<group>"; };
 		9A29E6E9297E233900D4A433 /* BasicTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTextField.swift; sourceTree = "<group>"; };
+		A96B8A0A2981706C00905BC9 /* BasicTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTextView.swift; sourceTree = "<group>"; };
+		A96B8A0C2981714800905BC9 /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
 		B7323F5DF501B54C2FAD4892 /* Pods_GetARock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetARock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8468F5E29797E7D00A9E77E /* MapsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MapsInfo.plist; sourceTree = "<group>"; };
 		B8468F6029797EFE00A9E77E /* Bundle+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Extension.swift"; sourceTree = "<group>"; };
@@ -132,7 +136,8 @@
 			isa = PBXGroup;
 			children = (
 				4AF584592978E497008F4068 /* UIView+Constraints.swift */,
-				9A29E6E7297E223A00D4A433 /* TextFieldSize.swift */,
+				9A29E6E7297E223A00D4A433 /* BasicComponentSize.swift */,
+				A96B8A0C2981714800905BC9 /* BasicLabel.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -281,6 +286,7 @@
 			children = (
 				B88E1BDE2977ACB6006072B7 /* SampleView.swift */,
 				9A29E6E9297E233900D4A433 /* BasicTextField.swift */,
+				A96B8A0A2981706C00905BC9 /* BasicTextView.swift */,
 			);
 			path = UIComponent;
 			sourceTree = "<group>";
@@ -532,6 +538,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B88E1BD92977ABD9006072B7 /* StringLiteral.swift in Sources */,
+				A96B8A0D2981714800905BC9 /* BasicLabel.swift in Sources */,
 				B88E1BD72977AB3D006072B7 /* ImageLiteral.swift in Sources */,
 				B88E1BE52977AEC2006072B7 /* LandingViewController.swift in Sources */,
 				4AF5845A2978E497008F4068 /* UIView+Constraints.swift in Sources */,
@@ -540,7 +547,8 @@
 				B88E1BD32977A95E006072B7 /* BaseViewController.swift in Sources */,
 				B88E1B9F2977A70E006072B7 /* AppDelegate.swift in Sources */,
 				B8468F6129797EFE00A9E77E /* Bundle+Extension.swift in Sources */,
-				9A29E6E8297E223A00D4A433 /* TextFieldSize.swift in Sources */,
+				A96B8A0B2981706C00905BC9 /* BasicTextView.swift in Sources */,
+				9A29E6E8297E223A00D4A433 /* BasicComponentSize.swift in Sources */,
 				B88E1BA12977A70E006072B7 /* SceneDelegate.swift in Sources */,
 				7BEA1875297AA10800A40488 /* UIFont+Extension.swift in Sources */,
 				9A29E6E6297E21C500D4A433 /* UITextField+Extension.swift in Sources */,

--- a/GetARock/GetARock/Global/Extension/UITextField+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/UITextField+Extension.swift
@@ -9,7 +9,6 @@ import UIKit
 extension UITextField {
     static func makeBasicTextField(placeholder: String, characterLimit: Int? = nil) -> UITextField {
         let textField: UITextField = {
-            
             $0.attributedPlaceholder = NSAttributedString(
                 string: placeholder,
                 attributes: [.foregroundColor: UIColor.gray02, .font: UIFont.setFont(.content)]

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -96,27 +96,10 @@ extension BasicTextView: UITextViewDelegate {
 }
 
 //MARK: Test code case1
-// 기본 텍스트뷰 (글자수 제한 300) + UIStackView에 사용하는 경우 (stackView의 크기에 맞춤)
-class BasicTextViewTestClass: UIViewController {
+// 기본 글자수 제한 300 + x,y 위치만 잡아주는 경우 (클래스 내에서 지정된 원래 크기로 할당됨)
+class BasicTextViewfirstTestClass: BaseViewController {
 
-    let firstTestTextView = BasicTextView(placeholder: "테스트용 텍스트뷰 입니다")
-
-    lazy var stackView = UIStackView(arrangedSubviews: [firstTestTextView])
-
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.addSubview(stackView)
-        stackView.constraint(centerX: view.centerXAnchor, centerY: view.centerYAnchor)
-        stackView.constraint(.widthAnchor, constant: 200)
-        stackView.constraint(.heightAnchor, constant: 400)
-    }
-}
-
-//MARK: Test code case2
-// 글자수 제한 30 + x,y 위치만 잡아주는 경우 (클래스 내에서 지정된 원래 크기로 할당됨)
-class BasicTextViewSecondTestClass: UIViewController {
-
-    let secondTestTextView = BasicTextView(placeholder: "테스트용", maxCount: 30)
+    let secondTestTextView = BasicTextView(placeholder: "테스트용 텍스트뷰 입니다")
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -126,3 +109,19 @@ class BasicTextViewSecondTestClass: UIViewController {
     }
 }
 
+//MARK: Test code case2
+// 글자수 제한 30 + UIStackView에 사용하는 경우 (stackView의 크기에 맞춤)
+class BasicTextViewSecondTestClass: BaseViewController {
+
+    let firstTestTextView = BasicTextView(placeholder: "테스트용", maxCount: 30)
+
+    lazy var stackView = UIStackView(arrangedSubviews: [firstTestTextView])
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(stackView)
+        stackView.constraint(centerX: view.centerXAnchor, centerY: view.centerYAnchor)
+        stackView.constraint(.widthAnchor, constant: 300)
+        stackView.constraint(.heightAnchor, constant: 200)
+    }
+}

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -1,0 +1,70 @@
+//
+//  BasicTextView.swift
+//  GetARock
+//
+//  Created by Jisu Jang on 2023/01/25.
+//
+
+import UIKit
+
+class BasicTextView: UIView {
+
+    private let placeholder: String
+
+    private var maxCount: Int = 300
+
+    private lazy var textView: UITextView = {
+        // 행간 세팅
+        let style = NSMutableParagraphStyle()
+        let attributedString = NSMutableAttributedString(string: textView.text)
+        style.lineSpacing = CGFloat(7)
+        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSRange(location: 0, length: attributedString.length))
+
+        $0.attributedText = attributedString
+        $0.font = UIFont.setFont(.content)
+        $0.textColor = .white
+        $0.backgroundColor = .dark02
+
+//        $0.delegate = self
+
+        return $0
+    }(UITextView())
+
+    private lazy var countLabel = BasicLabel(contentText: "\(textView.text.count)/\(maxCount)", fontStyle: .headline01, textColorInfo: .gray02)
+
+    private lazy var placeholderLabel: UILabel = BasicLabel(contentText: placeholder, fontStyle: .content, textColorInfo: .gray02)
+
+    init(placeholder: String, maxCount: Int? = nil) {
+        self.placeholder = placeholder
+        if let maxCount { self.maxCount = maxCount }
+        super.init(frame: .zero)
+        setupLayout()
+        attribute()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func attribute() {
+        self.layer.borderWidth = 1
+        self.layer.cornerRadius = 10
+        self.layer.borderColor = UIColor.white.cgColor
+        self.backgroundColor = .dark02
+        placeholderLabel.numberOfLines = 2
+    }
+
+    private func setupLayout() {
+        self.constraint(.widthAnchor, constant: TextViewSize.width)
+        self.constraint(.heightAnchor, constant: TextViewSize.height)
+
+        self.addSubview(textView)
+        textView.constraint(top: self.topAnchor, leading: self.leadingAnchor, bottom: self.bottomAnchor, trailing: self.trailingAnchor, padding: UIEdgeInsets(top: 10, left: 10, bottom:50, right: 10))
+
+        self.addSubview(countLabel)
+        countLabel.constraint(bottom: self.bottomAnchor, trailing: self.trailingAnchor, padding: UIEdgeInsets(top: 10, left: 10, bottom: 20, right: 20))
+
+        self.addSubview(placeholderLabel)
+        placeholderLabel.constraint(top: self.topAnchor, leading: self.leadingAnchor, padding: UIEdgeInsets(top: 15, left: 20, bottom: 0, right: 0))
+    }
+}

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -25,8 +25,7 @@ class BasicTextView: UIView {
         $0.textColor = .white
         $0.backgroundColor = .dark02
 
-//        $0.delegate = self
-
+        $0.delegate = self
         return $0
     }(UITextView())
 
@@ -66,5 +65,34 @@ class BasicTextView: UIView {
 
         self.addSubview(placeholderLabel)
         placeholderLabel.constraint(top: self.topAnchor, leading: self.leadingAnchor, padding: UIEdgeInsets(top: 15, left: 20, bottom: 0, right: 0))
+    }
+}
+
+extension BasicTextView: UITextViewDelegate {
+
+    func textViewDidChange(_ textView: UITextView) {
+        // text 숫자 업데이트
+        countLabel.text = "\(textView.text.count)/\(maxCount)"
+
+        // 최대 글자수 제한 로직
+        if let text = textView.text {
+            if text.count >= maxCount {
+                let maxCountIndex = text.index(text.startIndex, offsetBy: maxCount)
+                let fixedText = String(text[text.startIndex..<maxCountIndex])
+                textView.text = fixedText + " "
+                self.countLabel.text = "\(maxCount)/\(maxCount)"
+                self.textView.text = fixedText
+            }
+        }
+    }
+
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        placeholderLabel.isHidden = true
+    }
+
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.isEmpty {
+            placeholderLabel.isHidden = false
+        }
     }
 }

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -17,8 +17,11 @@ final class BasicTextView: UIView {
         let style = NSMutableParagraphStyle()
         let attributedString = NSMutableAttributedString(string: $0.text)
         style.lineSpacing = CGFloat(10)
-        attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSRange(location: 0, length: attributedString.length))
-
+        attributedString.addAttribute(
+            NSAttributedString.Key.paragraphStyle,
+            value: style,
+            range: NSRange(location: 0, length: attributedString.length)
+        )
         $0.attributedText = attributedString
         $0.font = UIFont.setFont(.content)
         $0.textColor = .white
@@ -28,9 +31,17 @@ final class BasicTextView: UIView {
         return $0
     }(UITextView())
 
-    private lazy var countLabel = BasicLabel(contentText: "\(textView.text.count)/\(maxCount)", fontStyle: .content, textColorInfo: .gray02)
+    private lazy var countLabel = BasicLabel(
+        contentText: "\(textView.text.count)/\(maxCount)",
+        fontStyle: .content,
+        textColorInfo: .gray02
+    )
 
-    private lazy var placeholderLabel: UILabel = BasicLabel(contentText: placeholder, fontStyle: .content, textColorInfo: .gray02)
+    private lazy var placeholderLabel: UILabel = BasicLabel(
+        contentText: placeholder,
+        fontStyle: .content,
+        textColorInfo: .gray02
+    )
 
     init(placeholder: String, maxCount: Int? = nil) {
         self.placeholder = placeholder
@@ -57,13 +68,27 @@ final class BasicTextView: UIView {
         self.constraint(.heightAnchor, constant: TextViewSize.height)
 
         self.addSubview(textView)
-        textView.constraint(top: self.topAnchor, leading: self.leadingAnchor, bottom: self.bottomAnchor, trailing: self.trailingAnchor, padding: UIEdgeInsets(top: 10, left: 10, bottom:50, right: 10))
+        textView.constraint(
+            top: self.topAnchor,
+            leading: self.leadingAnchor,
+            bottom: self.bottomAnchor,
+            trailing: self.trailingAnchor,
+            padding: UIEdgeInsets(top: 10, left: 10, bottom:50, right: 10)
+        )
 
         self.addSubview(countLabel)
-        countLabel.constraint(bottom: self.bottomAnchor, trailing: self.trailingAnchor, padding: UIEdgeInsets(top: 10, left: 10, bottom: 20, right: 20))
+        countLabel.constraint(
+            bottom: self.bottomAnchor,
+            trailing: self.trailingAnchor,
+            padding: UIEdgeInsets(top: 10, left: 10, bottom: 20, right: 20)
+        )
 
         self.addSubview(placeholderLabel)
-        placeholderLabel.constraint(top: self.topAnchor, leading: self.leadingAnchor, padding: UIEdgeInsets(top: 15, left: 20, bottom: 0, right: 0))
+        placeholderLabel.constraint(
+            top: self.topAnchor,
+            leading: self.leadingAnchor,
+            padding: UIEdgeInsets(top: 15, left: 20, bottom: 0, right: 0)
+        )
     }
 }
 
@@ -105,7 +130,11 @@ class BasicTextViewfirstTestClass: BaseViewController {
         super.viewDidLoad()
 
         view.addSubview(secondTestTextView)
-        secondTestTextView.constraint(centerX: view.centerXAnchor, centerY: view.centerYAnchor, padding: UIEdgeInsets(top: 30, left: 0, bottom: 0, right: 0))
+        secondTestTextView.constraint(
+            centerX: view.centerXAnchor,
+            centerY: view.centerYAnchor,
+            padding: UIEdgeInsets(top: 30, left: 0, bottom: 0, right: 0)
+        )
     }
 }
 
@@ -119,6 +148,7 @@ class BasicTextViewSecondTestClass: BaseViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
         view.addSubview(stackView)
         stackView.constraint(centerX: view.centerXAnchor, centerY: view.centerYAnchor)
         stackView.constraint(.widthAnchor, constant: 300)

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -6,7 +6,7 @@
 //
 import UIKit
 
-class BasicTextView: UIView {
+final class BasicTextView: UIView {
 
     private let placeholder: String
 

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -15,7 +15,7 @@ final class BasicTextView: UIView {
     private lazy var textView: UITextView = {
         // 행간 세팅
         let style = NSMutableParagraphStyle()
-        let attributedString = NSMutableAttributedString(string: textView.text)
+        let attributedString = NSMutableAttributedString(string: $0.text)
         style.lineSpacing = CGFloat(7)
         attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSRange(location: 0, length: attributedString.length))
 

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Jisu Jang on 2023/01/25.
 //
-
 import UIKit
 
 class BasicTextView: UIView {
@@ -73,7 +72,6 @@ extension BasicTextView: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         // text 숫자 업데이트
         countLabel.text = "\(textView.text.count)/\(maxCount)"
-
         // 최대 글자수 제한 로직
         if let text = textView.text {
             if text.count >= maxCount {
@@ -96,3 +94,35 @@ extension BasicTextView: UITextViewDelegate {
         }
     }
 }
+
+//MARK: Test code case1
+// 기본 텍스트뷰 (글자수 제한 300) + UIStackView에 사용하는 경우 (stackView의 크기에 맞춤)
+class BasicTextViewTestClass: UIViewController {
+
+    let firstTestTextView = BasicTextView(placeholder: "테스트용 텍스트뷰 입니다")
+
+    lazy var stackView = UIStackView(arrangedSubviews: [firstTestTextView])
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(stackView)
+        stackView.constraint(centerX: view.centerXAnchor, centerY: view.centerYAnchor)
+        stackView.constraint(.widthAnchor, constant: 200)
+        stackView.constraint(.heightAnchor, constant: 400)
+    }
+}
+
+//MARK: Test code case2
+// 글자수 제한 30 + x,y 위치만 잡아주는 경우 (클래스 내에서 지정된 원래 크기로 할당됨)
+class BasicTextViewSecondTestClass: UIViewController {
+
+    let secondTestTextView = BasicTextView(placeholder: "테스트용", maxCount: 30)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.addSubview(secondTestTextView)
+        secondTestTextView.constraint(centerX: view.centerXAnchor, centerY: view.centerYAnchor, padding: UIEdgeInsets(top: 30, left: 0, bottom: 0, right: 0))
+    }
+}
+

--- a/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextView.swift
@@ -16,7 +16,7 @@ final class BasicTextView: UIView {
         // 행간 세팅
         let style = NSMutableParagraphStyle()
         let attributedString = NSMutableAttributedString(string: $0.text)
-        style.lineSpacing = CGFloat(7)
+        style.lineSpacing = CGFloat(10)
         attributedString.addAttribute(NSAttributedString.Key.paragraphStyle, value: style, range: NSRange(location: 0, length: attributedString.length))
 
         $0.attributedText = attributedString
@@ -28,7 +28,7 @@ final class BasicTextView: UIView {
         return $0
     }(UITextView())
 
-    private lazy var countLabel = BasicLabel(contentText: "\(textView.text.count)/\(maxCount)", fontStyle: .headline01, textColorInfo: .gray02)
+    private lazy var countLabel = BasicLabel(contentText: "\(textView.text.count)/\(maxCount)", fontStyle: .content, textColorInfo: .gray02)
 
     private lazy var placeholderLabel: UILabel = BasicLabel(contentText: placeholder, fontStyle: .content, textColorInfo: .gray02)
 

--- a/GetARock/GetARock/Global/Utils/BasicComponentSize.swift
+++ b/GetARock/GetARock/Global/Utils/BasicComponentSize.swift
@@ -11,3 +11,7 @@ struct TextFieldSize {
     static let height = CGFloat(55)
 }
 
+struct TextViewSize {
+    static let width = UIScreen.main.bounds.width * 0.9
+    static let height = CGFloat(250)
+}

--- a/GetARock/GetARock/Global/Utils/BasicLabel.swift
+++ b/GetARock/GetARock/Global/Utils/BasicLabel.swift
@@ -1,0 +1,30 @@
+//
+//  BasicLabel.swift
+//  GetARock
+//
+//  Created by Jisu Jang on 2023/01/25.
+//
+import UIKit
+
+class BasicLabel: UILabel {
+
+    private let contentText: String
+    private let fontStyle: FontType
+    private let textColorInfo: UIColor
+
+    init(contentText: String, fontStyle: FontType, textColorInfo: UIColor) {
+        self.contentText = contentText
+        self.fontStyle = fontStyle
+        self.textColorInfo = textColorInfo
+        super.init(frame: .zero)
+
+        self.text = contentText
+        self.font = UIFont.setFont(fontStyle)
+        self.textColor = textColorInfo
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+}

--- a/GetARock/GetARock/Global/Utils/BasicLabel.swift
+++ b/GetARock/GetARock/Global/Utils/BasicLabel.swift
@@ -6,7 +6,7 @@
 //
 import UIKit
 
-class BasicLabel: UILabel {
+final class BasicLabel: UILabel {
 
     private let contentText: String
     private let fontStyle: FontType


### PR DESCRIPTION
## 관련 이슈
-  #26 

## 배경
 밴드 생성 및 회원가입에 사용되는 기본 TextView를 구현합니다.

####  아래 사진에서 보이는 TextView를 만들었습니다.

  <img width="300" alt="스크린샷1" src="https://user-images.githubusercontent.com/103009135/214612092-e5517b9a-e51e-44fd-9334-bcee17df77a1.png">

## 작업 내용
### 텍스트뷰 구성

BasicTextView는 다음과 같은 구성을 가집니다.

1. UIView를 상속하는 class입니다.
2. 프로퍼티로 UITextView, 글자수를 나타내는 UILabel, 플레이스홀더 역할을 하는 UILabel 을 포함합니다.
3. UITextView Delegate를 채택해서 글자수 실시간 업데이트와 글자수 제한 기능을 수행합니다.

### 텍스트 글자수 제한 로직

- textView 델리게이트 함수 내에 제한 글자수 이상이면 문자열을 설정 범위까지 슬라이싱해서 제한된 글자만 표기합니다 (fixedText)

### ❗️사용법

    let secondTestTextView = BasicTextView(placeholder: "테스트용 텍스트뷰 입니다")

- init할 때 placeholder를 필수로 받습니다. placeholder에서 줄바꿈이 필요하다면 \n 식으로 중간에 개행문자를 넣어주세요! ex. 작성해주신 정보는 내 프로필로 만들어지고\n프로필은 다른 사용자들이 볼 수 있어요

- optional로 최대 글자수 제한을 줄 수 있습니다. 아무것도 안넣을 경우 기본 300자로 제한됩니다.

### 기타사항
- 커스텀 UILabel인 BasicLabel이 추가되었습니다. 
텍스트와 폰트타입, 글자 색상을 받아 쉽게 정해진 형식의 UILabel을 만들 수 있습니다. 추후에 UILabel을 만드는 작업이 너무 많이 반복되서 미리 정해진 구조로 만들어놓았습니다. 이건 공통컴포넌트로 합의된 사항이 없었기에... 그냥 Util 파일에 넣게 되었습니다! 

https://github.com/extreme-rock/GetARock-iOS/blob/a9ca1c4dbc25a4cc4738c81e1ac928972f0c3c34/GetARock/GetARock/Global/Utils/BasicLabel.swift#L7-L30

- BasicTextView의 기본 사이즈를 매직넘버로 관리하는 코드가 추가되었습니다.

## 리뷰 노트
- 컨벤션이 아직 적응이 덜되서 미처 놓친부분이 없는지 궁금하네용
- 불필요한 코드가 쓰이지 않았나 궁금해요
- 조금이라도 개선의 여지가 있는 코드면 가차없는 의견 부탁드립니다!!
- 디자인에서 제가 놓친부분이 있는지 궁금하네요 텍스트 필드 내의 입력글자가 좀 작은가 하는 생각이 들기도 합니다

## 테스트 방법

        window.rootViewController = BasicTextViewfirstTestClass()

        window.rootViewController = BasicTextViewSecondTestClass()

BasicTextView 파일에 두 가지 테스트코드를 짜놓았습니다.
StackView를 사용한 경우와 일반적인 constraint를 준 경우, 글자수 제한을 조절할 수 있는 두 가지 경우로 테스트가 가능합니다!
