### PR TITLE
[!HOTFIX] DefaultButton의 그라데이션이 깨지는 문제를 해결했습니다.

### DIFF
--- a/GetARock/GetARock/Global/UIComponent/DefaultButton.swift
+++ b/GetARock/GetARock/Global/UIComponent/DefaultButton.swift
@@ -12,18 +12,13 @@ final class DefaultButton: UIButton {
     override func setNeedsLayout() {
         self.applyActiveGradation()
     }
-    
-    init(borderBounds: CGRect) {
-        super.init(frame: .zero)
-        attribute(bounds: borderBounds)
+
+    override func draw(_ rect: CGRect) {
+        super.draw(rect)
+        attribute()
     }
-    
-    required init(coder: NSCoder) {
-        fatalError("init(codexr:) has not been implemented")
-    }
-    
-    private func attribute(bounds: CGRect) {
-        let gradientImage = UIImage.gradientImage(bounds: bounds, colors: [.mainPurple, .blue02])
+    private func attribute() {
+        let gradientImage = UIImage.gradientImage(bounds: self.bounds, colors: [.mainPurple, .blue02])
         let color = UIColor(patternImage: gradientImage)
         layer.borderColor = color.cgColor
         layer.borderWidth = 1


### PR DESCRIPTION
<!-- 불필요한 항목은 삭제해주세요 -->


## 관련 이슈
- Close #65 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경
- 기존에는 DefaultButton을 init할 때 border의 크기를 CGRect값으로 전달해줘야했습니다. 따라서 Button의 AutoLayout의 값을 유동적으로 대처하기가 어려워 gradient가 깨지는 경우가 있었습니다.

<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
- 따라서 Button의 Layout이 잡힌 이후 실행되는 draw싸이클에서 attribute()를 실행하여 UIButton의 사이즈에 유동적으로 대응할 수 있습니다. 
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 리뷰 노트

<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 테스트 방법

<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 스크린샷

<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->

<!--## 해당 PR 확정 사항-->

<!-- 해당 PR 리뷰 과정에서 논의된 확정 사항을 develop 브랜치에 머지하기 전 정리합니다. -->
