### PR TITLE
[Design] 밴드 정보 생성하기에서 밴드 리더가 포지션을 선택할 수 있는 View를 구현합니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		9A3F07752987E1DB009CD500 /* TextLimitTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */; };
 		9A78BFE3298A9CD900953E4B /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE2298A9CD900953E4B /* NetworkError.swift */; };
 		9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */; };
+		9AEA7E7B299A5B44006A730A /* BandMemberAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEA7E7A299A5B44006A730A /* BandMemberAddViewController.swift */; };
 		9AFE0142299906E0004B0BCF /* LeaderPositionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */; };
 		9AFE014529990754004B0BCF /* LeaderPositionSelectHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */; };
 		9AFE014729990FE0004B0BCF /* BandInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE014629990FE0004B0BCF /* BandInformationDTO.swift */; };
@@ -141,6 +142,7 @@
 		9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLimitTextField.swift; sourceTree = "<group>"; };
 		9A78BFE2298A9CD900953E4B /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicationCheckRequest.swift; sourceTree = "<group>"; };
+		9AEA7E7A299A5B44006A730A /* BandMemberAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandMemberAddViewController.swift; sourceTree = "<group>"; };
 		9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectViewController.swift; sourceTree = "<group>"; };
 		9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectHeaderView.swift; sourceTree = "<group>"; };
 		9AFE014629990FE0004B0BCF /* BandInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandInformationDTO.swift; sourceTree = "<group>"; };
@@ -272,6 +274,7 @@
 			children = (
 				9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */,
 				9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */,
+				9AEA7E7A299A5B44006A730A /* BandMemberAddViewController.swift */,
 			);
 			path = BandCreation;
 			sourceTree = "<group>";
@@ -748,6 +751,7 @@
 				9A29E6E8297E223A00D4A433 /* BasicComponentSize.swift in Sources */,
 				A951F6532989EF6C00902CED /* String+Extension.swift in Sources */,
 				7BC275602987EA10008F4B9F /* emptyView.swift in Sources */,
+				9AEA7E7B299A5B44006A730A /* BandMemberAddViewController.swift in Sources */,
 				B88E1BA12977A70E006072B7 /* SceneDelegate.swift in Sources */,
 				B8B17C4F2980B67C00806899 /* Band.swift in Sources */,
 				4A00132B29835CF600EA992E /* UIImage+Extension.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -8,13 +8,13 @@
 
 /* Begin PBXBuildFile section */
 		2A35EDA1F6F1B54EC4E9AEF0 /* Pods_GetARock_GetARockUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CDE4C1D1C0D8EC9E6B8B706 /* Pods_GetARock_GetARockUITests.framework */; };
-		4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */; };
-		4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */; };
 		4A00132B29835CF600EA992E /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A00132A29835CF600EA992E /* UIImage+Extension.swift */; };
 		4A08A9B4297BB0A300822FF9 /* PositionCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B3297BB0A300822FF9 /* PositionCollectionView.swift */; };
 		4A08A9B6297BC39000822FF9 /* PositionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B5297BC39000822FF9 /* PositionCollectionViewCell.swift */; };
 		4A08A9B8297C05F800822FF9 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B7297C05F800822FF9 /* NSObject+Extension.swift */; };
 		4A20270D2983FF410042EEFA /* NegativeDefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20270C2983FF410042EEFA /* NegativeDefaultButton.swift */; };
+		4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */; };
+		4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */; };
 		4A2027162987627E0042EEFA /* PositionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2027152987627E0042EEFA /* PositionSelectViewController.swift */; };
 		4A59318A2989041200C8DA31 /* PlusPositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5931892989041200C8DA31 /* PlusPositionViewController.swift */; };
 		4A59318C29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59318B29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift */; };
@@ -47,6 +47,8 @@
 		9A3F07752987E1DB009CD500 /* TextLimitTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */; };
 		9A78BFE3298A9CD900953E4B /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE2298A9CD900953E4B /* NetworkError.swift */; };
 		9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */; };
+		9AFE0142299906E0004B0BCF /* LeaderPositionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */; };
+		9AFE014529990754004B0BCF /* LeaderPositionSelectHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */; };
 		A769E177D6AA52251CAA0997 /* Pods_GetARockTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F817079C25E9C663E82B27 /* Pods_GetARockTests.framework */; };
 		A951F6532989EF6C00902CED /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951F6522989EF6C00902CED /* String+Extension.swift */; };
 		A96B8A0B2981706C00905BC9 /* BasicTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0A2981706C00905BC9 /* BasicTextView.swift */; };
@@ -95,13 +97,13 @@
 		159F0019C5C9AB3A427BD907 /* Pods-GetARockTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetARockTests.release.xcconfig"; path = "Target Support Files/Pods-GetARockTests/Pods-GetARockTests.release.xcconfig"; sourceTree = "<group>"; };
 		1C72EC7590FAAB055CED6028 /* Pods-GetARockTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetARockTests.debug.xcconfig"; path = "Target Support Files/Pods-GetARockTests/Pods-GetARockTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2CDE4C1D1C0D8EC9E6B8B706 /* Pods_GetARock_GetARockUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetARock_GetARockUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPageSegmentedControl.swift; sourceTree = "<group>"; };
-		4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationPageSegmentedControl.swift; sourceTree = "<group>"; };
 		4A00132A29835CF600EA992E /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		4A08A9B3297BB0A300822FF9 /* PositionCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionView.swift; sourceTree = "<group>"; };
 		4A08A9B5297BC39000822FF9 /* PositionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A08A9B7297C05F800822FF9 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		4A20270C2983FF410042EEFA /* NegativeDefaultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NegativeDefaultButton.swift; sourceTree = "<group>"; };
+		4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPageSegmentedControl.swift; sourceTree = "<group>"; };
+		4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationPageSegmentedControl.swift; sourceTree = "<group>"; };
 		4A2027152987627E0042EEFA /* PositionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSelectViewController.swift; sourceTree = "<group>"; };
 		4A5931892989041200C8DA31 /* PlusPositionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPositionViewController.swift; sourceTree = "<group>"; };
 		4A59318B29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSelectCollectionViewHeader.swift; sourceTree = "<group>"; };
@@ -125,7 +127,6 @@
 		7B76C5E72982D54100076637 /* SongListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongListCollectionViewCell.swift; sourceTree = "<group>"; };
 		7B7B04132988FC1100186986 /* SNSListStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSListStackView.swift; sourceTree = "<group>"; };
 		7B7B04152988FE9900186986 /* SNS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNS.swift; sourceTree = "<group>"; };
-
 		7BC2755D2987DF54008F4B9F /* BandButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandButtonView.swift; sourceTree = "<group>"; };
 		7BC2755F2987EA10008F4B9F /* emptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = emptyView.swift; sourceTree = "<group>"; };
 		7BC8E09C297C0BE6008FD5FE /* UIView+Gradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Gradation.swift"; sourceTree = "<group>"; };
@@ -138,6 +139,8 @@
 		9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLimitTextField.swift; sourceTree = "<group>"; };
 		9A78BFE2298A9CD900953E4B /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicationCheckRequest.swift; sourceTree = "<group>"; };
+		9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectViewController.swift; sourceTree = "<group>"; };
+		9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectHeaderView.swift; sourceTree = "<group>"; };
 		A951F6522989EF6C00902CED /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		A96B8A0A2981706C00905BC9 /* BasicTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTextView.swift; sourceTree = "<group>"; };
 		A96B8A0C2981714800905BC9 /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
@@ -259,6 +262,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		9AFE014329990705004B0BCF /* BandCreation */ = {
+			isa = PBXGroup;
+			children = (
+				9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */,
+				9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */,
+			);
+			path = BandCreation;
+			sourceTree = "<group>";
+		};
 		B8468F62297A94B900A9E77E /* Maps */ = {
 			isa = PBXGroup;
 			children = (
@@ -340,6 +352,7 @@
 				4A202714298761DA0042EEFA /* SignUp */,
 				B8468F62297A94B900A9E77E /* Maps */,
 				B88E1BE22977AE1D006072B7 /* Landing */,
+				9AFE014329990705004B0BCF /* BandCreation */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -693,6 +706,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				7B7B04162988FE9900186986 /* SNS.swift in Sources */,
+				9AFE014529990754004B0BCF /* LeaderPositionSelectHeaderView.swift in Sources */,
 				B88E1BD92977ABD9006072B7 /* StringLiteral.swift in Sources */,
 				9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */,
 				A96B8A0D2981714800905BC9 /* BasicLabel.swift in Sources */,
@@ -730,6 +744,7 @@
 				B8B17C4F2980B67C00806899 /* Band.swift in Sources */,
 				4A00132B29835CF600EA992E /* UIImage+Extension.swift in Sources */,
 				4AC4CE47297FDFB500BB823C /* BottomButton.swift in Sources */,
+				9AFE0142299906E0004B0BCF /* LeaderPositionSelectViewController.swift in Sources */,
 				4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */,
 				4A59318A2989041200C8DA31 /* PlusPositionViewController.swift in Sources */,
 				7BEA1875297AA10800A40488 /* UIFont+Extension.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		9A3F07752987E1DB009CD500 /* TextLimitTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */; };
 		9A78BFE3298A9CD900953E4B /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE2298A9CD900953E4B /* NetworkError.swift */; };
 		9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */; };
+		9ACA585A299B71DD00C6C2BC /* MemberState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9ACA5859299B71DD00C6C2BC /* MemberState.swift */; };
 		9AEA7E7B299A5B44006A730A /* BandMemberAddViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AEA7E7A299A5B44006A730A /* BandMemberAddViewController.swift */; };
 		9AFE0142299906E0004B0BCF /* LeaderPositionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */; };
 		9AFE014529990754004B0BCF /* LeaderPositionSelectHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */; };
@@ -142,6 +143,7 @@
 		9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLimitTextField.swift; sourceTree = "<group>"; };
 		9A78BFE2298A9CD900953E4B /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicationCheckRequest.swift; sourceTree = "<group>"; };
+		9ACA5859299B71DD00C6C2BC /* MemberState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemberState.swift; sourceTree = "<group>"; };
 		9AEA7E7A299A5B44006A730A /* BandMemberAddViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandMemberAddViewController.swift; sourceTree = "<group>"; };
 		9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectViewController.swift; sourceTree = "<group>"; };
 		9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectHeaderView.swift; sourceTree = "<group>"; };
@@ -472,6 +474,7 @@
 				B8B17C532980B99900806899 /* Coordinate.swift */,
 				B8B17C5C29823AC900806899 /* Event.swift */,
 				9AFE014629990FE0004B0BCF /* BandInformationDTO.swift */,
+				9ACA5859299B71DD00C6C2BC /* MemberState.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -725,6 +728,7 @@
 				4AF5845A2978E497008F4068 /* UIView+Constraints.swift in Sources */,
 				9A29E6EA297E233900D4A433 /* BasicTextField.swift in Sources */,
 				4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */,
+				9ACA585A299B71DD00C6C2BC /* MemberState.swift in Sources */,
 				B88E1BDF2977ACB6006072B7 /* SampleView.swift in Sources */,
 				9AFE014729990FE0004B0BCF /* BandInformationDTO.swift in Sources */,
 				B88E1BD32977A95E006072B7 /* BaseViewController.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 		A951F6532989EF6C00902CED /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951F6522989EF6C00902CED /* String+Extension.swift */; };
 		A96B8A0B2981706C00905BC9 /* BasicTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0A2981706C00905BC9 /* BasicTextView.swift */; };
 		A96B8A0D2981714800905BC9 /* BasicLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0C2981714800905BC9 /* BasicLabel.swift */; };
-		A9EDD38E299A3115003F5392 /* ModelData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EDD38D299A3114003F5392 /* ModelData.swift */; };
+		A9EDD38E299A3115003F5392 /* BasicDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EDD38D299A3114003F5392 /* BasicDataModel.swift */; };
 		B808B6972982A85F00A1A9E2 /* CustomMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B808B6962982A85F00A1A9E2 /* CustomMarker.swift */; };
 		B8468F5F29797E7D00A9E77E /* MapsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = B8468F5E29797E7D00A9E77E /* MapsInfo.plist */; };
 		B8468F6129797EFE00A9E77E /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8468F6029797EFE00A9E77E /* Bundle+Extension.swift */; };
@@ -149,7 +149,7 @@
 		A951F6522989EF6C00902CED /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		A96B8A0A2981706C00905BC9 /* BasicTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTextView.swift; sourceTree = "<group>"; };
 		A96B8A0C2981714800905BC9 /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
-		A9EDD38D299A3114003F5392 /* ModelData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelData.swift; sourceTree = "<group>"; };
+		A9EDD38D299A3114003F5392 /* BasicDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicDataModel.swift; sourceTree = "<group>"; };
 		B7323F5DF501B54C2FAD4892 /* Pods_GetARock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetARock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B808B6962982A85F00A1A9E2 /* CustomMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMarker.swift; sourceTree = "<group>"; };
 		B8468F5E29797E7D00A9E77E /* MapsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MapsInfo.plist; sourceTree = "<group>"; };
@@ -254,7 +254,7 @@
 				4AF584592978E497008F4068 /* UIView+Constraints.swift */,
 				9A29E6E7297E223A00D4A433 /* BasicComponentSize.swift */,
 				A96B8A0C2981714800905BC9 /* BasicLabel.swift */,
-				A9EDD38D299A3114003F5392 /* ModelData.swift */,
+				A9EDD38D299A3114003F5392 /* BasicDataModel.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -731,7 +731,7 @@
 				9A78BFE3298A9CD900953E4B /* NetworkError.swift in Sources */,
 				4AC4CE4B2980B41400BB823C /* DefaultButton.swift in Sources */,
 				4AC4CE43297FB8AD00BB823C /* BandMember.swift in Sources */,
-				A9EDD38E299A3115003F5392 /* ModelData.swift in Sources */,
+				A9EDD38E299A3115003F5392 /* BasicDataModel.swift in Sources */,
 				4A08A9B6297BC39000822FF9 /* PositionCollectionViewCell.swift in Sources */,
 				4AC4CE41297FB85B00BB823C /* Position.swift in Sources */,
 				B8B17C522980B93300806899 /* Location.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		A951F6532989EF6C00902CED /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951F6522989EF6C00902CED /* String+Extension.swift */; };
 		A96B8A0B2981706C00905BC9 /* BasicTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0A2981706C00905BC9 /* BasicTextView.swift */; };
 		A96B8A0D2981714800905BC9 /* BasicLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0C2981714800905BC9 /* BasicLabel.swift */; };
+		A9EDD38E299A3115003F5392 /* ModelData.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9EDD38D299A3114003F5392 /* ModelData.swift */; };
 		B808B6972982A85F00A1A9E2 /* CustomMarker.swift in Sources */ = {isa = PBXBuildFile; fileRef = B808B6962982A85F00A1A9E2 /* CustomMarker.swift */; };
 		B8468F5F29797E7D00A9E77E /* MapsInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = B8468F5E29797E7D00A9E77E /* MapsInfo.plist */; };
 		B8468F6129797EFE00A9E77E /* Bundle+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8468F6029797EFE00A9E77E /* Bundle+Extension.swift */; };
@@ -146,6 +147,7 @@
 		A951F6522989EF6C00902CED /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		A96B8A0A2981706C00905BC9 /* BasicTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTextView.swift; sourceTree = "<group>"; };
 		A96B8A0C2981714800905BC9 /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
+		A9EDD38D299A3114003F5392 /* ModelData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelData.swift; sourceTree = "<group>"; };
 		B7323F5DF501B54C2FAD4892 /* Pods_GetARock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetARock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B808B6962982A85F00A1A9E2 /* CustomMarker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomMarker.swift; sourceTree = "<group>"; };
 		B8468F5E29797E7D00A9E77E /* MapsInfo.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = MapsInfo.plist; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 				4AF584592978E497008F4068 /* UIView+Constraints.swift */,
 				9A29E6E7297E223A00D4A433 /* BasicComponentSize.swift */,
 				A96B8A0C2981714800905BC9 /* BasicLabel.swift */,
+				A9EDD38D299A3114003F5392 /* ModelData.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -725,6 +728,7 @@
 				9A78BFE3298A9CD900953E4B /* NetworkError.swift in Sources */,
 				4AC4CE4B2980B41400BB823C /* DefaultButton.swift in Sources */,
 				4AC4CE43297FB8AD00BB823C /* BandMember.swift in Sources */,
+				A9EDD38E299A3115003F5392 /* ModelData.swift in Sources */,
 				4A08A9B6297BC39000822FF9 /* PositionCollectionViewCell.swift in Sources */,
 				4AC4CE41297FB85B00BB823C /* Position.swift in Sources */,
 				B8B17C522980B93300806899 /* Location.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */; };
 		9AFE0142299906E0004B0BCF /* LeaderPositionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */; };
 		9AFE014529990754004B0BCF /* LeaderPositionSelectHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */; };
+		9AFE014729990FE0004B0BCF /* BandInformationDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AFE014629990FE0004B0BCF /* BandInformationDTO.swift */; };
 		A769E177D6AA52251CAA0997 /* Pods_GetARockTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 77F817079C25E9C663E82B27 /* Pods_GetARockTests.framework */; };
 		A951F6532989EF6C00902CED /* String+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = A951F6522989EF6C00902CED /* String+Extension.swift */; };
 		A96B8A0B2981706C00905BC9 /* BasicTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A96B8A0A2981706C00905BC9 /* BasicTextView.swift */; };
@@ -141,6 +142,7 @@
 		9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicationCheckRequest.swift; sourceTree = "<group>"; };
 		9AFE0141299906E0004B0BCF /* LeaderPositionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectViewController.swift; sourceTree = "<group>"; };
 		9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LeaderPositionSelectHeaderView.swift; sourceTree = "<group>"; };
+		9AFE014629990FE0004B0BCF /* BandInformationDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandInformationDTO.swift; sourceTree = "<group>"; };
 		A951F6522989EF6C00902CED /* String+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Extension.swift"; sourceTree = "<group>"; };
 		A96B8A0A2981706C00905BC9 /* BasicTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicTextView.swift; sourceTree = "<group>"; };
 		A96B8A0C2981714800905BC9 /* BasicLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicLabel.swift; sourceTree = "<group>"; };
@@ -463,6 +465,7 @@
 				B8B17C512980B93300806899 /* Location.swift */,
 				B8B17C532980B99900806899 /* Coordinate.swift */,
 				B8B17C5C29823AC900806899 /* Event.swift */,
+				9AFE014629990FE0004B0BCF /* BandInformationDTO.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -717,6 +720,7 @@
 				9A29E6EA297E233900D4A433 /* BasicTextField.swift in Sources */,
 				4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */,
 				B88E1BDF2977ACB6006072B7 /* SampleView.swift in Sources */,
+				9AFE014729990FE0004B0BCF /* BandInformationDTO.swift in Sources */,
 				B88E1BD32977A95E006072B7 /* BaseViewController.swift in Sources */,
 				9A78BFE3298A9CD900953E4B /* NetworkError.swift in Sources */,
 				4AC4CE4B2980B41400BB823C /* DefaultButton.swift in Sources */,

--- a/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
+++ b/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-// MARK: - BandCreate
 struct BandInformationDTO: Codable {
     let name: String
     let address: Address
@@ -17,37 +16,43 @@ struct BandInformationDTO: Codable {
     let snsList: [SnsList]
 }
 
-// MARK: - Address
 struct Address: Codable {
     let city, street, detail: String
     let longitude, latitude: Double
 }
 
-// MARK: - MemberList
 struct MemberList: Codable {
-    let memberID: Int?
-    let name, memberState: String
+    let memberId: Int?
+    let name: String
+    let memberState: MemberState
     let instrumentList: [InstrumentList]
-
-    enum CodingKeys: String, CodingKey {
-        case memberID = "memberId"
-        case name, memberState, instrumentList
-    }
 }
 
-// MARK: - InstrumentList
 struct InstrumentList: Codable {
     let name: Name
 }
 
+//MARK: Name
 enum Name: String, Codable {
     case base = "base"
     case guitar = "guitar"
 }
 
+enum SnsType: String, Codable {
+    case youtube = "YOUTUBE"
+    case instagram = "INSTAGRAM"
+    case soundcloud = "SOUNDCLOUD"
+}
+
+enum MemberState: String, Codable {
+    case inviting = "INVITING"
+    case approved = "APPROVE"
+    case denied = "DENY"
+}
+
 // MARK: - SnsList
 struct SnsList: Codable {
-    let type: String
+    let type: SnsType
     let link: String?
 }
 

--- a/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
+++ b/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
@@ -10,10 +10,10 @@ import Foundation
 struct BandInformationDTO: Codable {
     let name: String
     let address: Address
-    let songList: [SongList]
+    let songList: [SongList]? // 정보 입력시 선택사항
     let memberList: [MemberList]
-    let introduction: String
-    let snsList: [SnsList]
+    let introduction: String? // 정보 입력시 선택사항
+    let snsList: [SnsList]? // 정보 입력시 선택사항
 }
 
 struct Address: Codable {
@@ -32,7 +32,6 @@ struct InstrumentList: Codable {
     let name: Name
 }
 
-//MARK: Name
 enum Name: String, Codable {
     case base = "base"
     case guitar = "guitar"
@@ -45,18 +44,17 @@ enum SnsType: String, Codable {
 }
 
 enum MemberState: String, Codable {
+    case admin = "ADMIN"
     case inviting = "INVITING"
     case approved = "APPROVE"
     case denied = "DENY"
 }
 
-// MARK: - SnsList
 struct SnsList: Codable {
     let type: SnsType
-    let link: String?
+    let link: String
 }
 
-// MARK: - SongList
 struct SongList: Codable {
     let name, artist: String
     let link: String?

--- a/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
+++ b/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
@@ -32,19 +32,6 @@ struct InstrumentList: Codable {
     let name: String
 }
 
-enum SnsType: String, Codable {
-    case youtube = "YOUTUBE"
-    case instagram = "INSTAGRAM"
-    case soundcloud = "SOUNDCLOUD"
-}
-
-enum MemberState: String, Codable {
-    case admin = "ADMIN"
-    case inviting = "INVITING"
-    case approved = "APPROVE"
-    case denied = "DENY"
-}
-
 struct SnsList: Codable {
     let type: SnsType
     let link: String

--- a/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
+++ b/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
@@ -11,7 +11,7 @@ struct BandInformationDTO: Codable {
     let name: String
     let address: Address
     let songList: [SongList]? // 정보 입력시 선택사항
-    let memberList: [MemberList]
+    var memberList: [MemberList]
     let introduction: String? // 정보 입력시 선택사항
     let snsList: [SnsList]? // 정보 입력시 선택사항
 }
@@ -29,12 +29,7 @@ struct MemberList: Codable {
 }
 
 struct InstrumentList: Codable {
-    let name: Name
-}
-
-enum Name: String, Codable {
-    case base = "base"
-    case guitar = "guitar"
+    let name: String
 }
 
 enum SnsType: String, Codable {

--- a/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
+++ b/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift
@@ -1,0 +1,58 @@
+//
+//  BandInformationDTO.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/02/12.
+//
+
+import Foundation
+
+// MARK: - BandCreate
+struct BandInformationDTO: Codable {
+    let name: String
+    let address: Address
+    let songList: [SongList]
+    let memberList: [MemberList]
+    let introduction: String
+    let snsList: [SnsList]
+}
+
+// MARK: - Address
+struct Address: Codable {
+    let city, street, detail: String
+    let longitude, latitude: Double
+}
+
+// MARK: - MemberList
+struct MemberList: Codable {
+    let memberID: Int?
+    let name, memberState: String
+    let instrumentList: [InstrumentList]
+
+    enum CodingKeys: String, CodingKey {
+        case memberID = "memberId"
+        case name, memberState, instrumentList
+    }
+}
+
+// MARK: - InstrumentList
+struct InstrumentList: Codable {
+    let name: Name
+}
+
+enum Name: String, Codable {
+    case base = "base"
+    case guitar = "guitar"
+}
+
+// MARK: - SnsList
+struct SnsList: Codable {
+    let type: String
+    let link: String?
+}
+
+// MARK: - SongList
+struct SongList: Codable {
+    let name, artist: String
+    let link: String?
+}

--- a/GetARock/GetARock/Global/Network/Model/MemberState.swift
+++ b/GetARock/GetARock/Global/Network/Model/MemberState.swift
@@ -10,4 +10,5 @@ enum MemberState: String, Codable {
     case inviting = "INVITING"
     case approved = "APPROVE"
     case denied = "DENY"
+    case annonymous = "ANNONYMOUS"
 }

--- a/GetARock/GetARock/Global/Network/Model/MemberState.swift
+++ b/GetARock/GetARock/Global/Network/Model/MemberState.swift
@@ -1,0 +1,13 @@
+//
+//  MemberState.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/02/14.
+//
+
+enum MemberState: String, Codable {
+    case admin = "ADMIN"
+    case inviting = "INVITING"
+    case approved = "APPROVE"
+    case denied = "DENY"
+}

--- a/GetARock/GetARock/Global/Network/Model/SNS.swift
+++ b/GetARock/GetARock/Global/Network/Model/SNS.swift
@@ -12,3 +12,9 @@ struct SNS {
     let instagram: String?
     let soundCloud: String?
 }
+
+enum SnsType: String, Codable {
+    case youtube = "YOUTUBE"
+    case instagram = "INSTAGRAM"
+    case soundcloud = "SOUNDCLOUD"
+}

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -45,7 +45,7 @@ final class PositionCollectionView: UIView {
     
     // MARK: - View
     
-    lazy var collectionView: UICollectionView = {
+    private lazy var collectionView: UICollectionView = {
         let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(CellSize.width),
                                               heightDimension: .absolute(138))
         let item1 = NSCollectionLayoutItem(layoutSize: itemSize)

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -183,3 +183,15 @@ extension PositionCollectionView: UICollectionViewDelegate {
         return canSelect
     }
 }
+//MARK: 선택된 포지션 데이터 추출
+extension PositionCollectionView {
+    func getSelectedInstruments() -> [InstrumentList] {
+        var selectedInstruments: [InstrumentList] = []
+        let selectedIndexPaths = self.collectionView.indexPathsForSelectedItems ?? []
+        for indexPath in selectedIndexPaths {
+            guard let cell =  self.collectionView.cellForItem(at: indexPath) as? PositionCollectionViewCell else { return [] }
+            selectedInstruments.append(InstrumentList(name: cell.positionNameLabel.text ?? ""))
+        }
+        return selectedInstruments
+    }
+}

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -45,7 +45,7 @@ final class PositionCollectionView: UIView {
     
     // MARK: - View
     
-    private lazy var collectionView: UICollectionView = {
+    lazy var collectionView: UICollectionView = {
         let itemSize = NSCollectionLayoutSize(widthDimension: .absolute(CellSize.width),
                                               heightDimension: .absolute(138))
         let item1 = NSCollectionLayoutItem(layoutSize: itemSize)
@@ -182,5 +182,4 @@ extension PositionCollectionView: UICollectionViewDelegate {
         guard let canSelect = delegate?.canSelectPosition(collectionView, indexPath: indexPath, selectedItemsCount: selectedPositionCount) else { return false }
         return canSelect
     }
-
 }

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionViewCell.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionViewCell.swift
@@ -35,7 +35,7 @@ final class PositionCollectionViewCell: UICollectionViewCell {
         return imageView
     }()
     
-    private let positionNameLabel: UILabel = {
+    let positionNameLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.setFont(.headline01)
         label.numberOfLines = 2

--- a/GetARock/GetARock/Global/Utils/BasicDataModel.swift
+++ b/GetARock/GetARock/Global/Utils/BasicDataModel.swift
@@ -5,7 +5,7 @@
 //  Created by Jisu Jang on 2023/02/13.
 //
 
-struct ModelData {
+struct BasicDataModel {
     static var bandCreationData: BandInformationDTO = BandInformationDTO(
         name: "user",
         address: Address(city: "default",

--- a/GetARock/GetARock/Global/Utils/ModelData.swift
+++ b/GetARock/GetARock/Global/Utils/ModelData.swift
@@ -1,0 +1,25 @@
+//
+//  ModelData.swift
+//  GetARock
+//
+//  Created by Jisu Jang on 2023/02/13.
+//
+
+struct ModelData {
+    static var bandCreationData: BandInformationDTO = BandInformationDTO(
+        name: "",
+        address: Address(city: "",
+                         street: "",
+                         detail: "",
+                         longitude: 0.0,
+                         latitude: 0.0),
+
+        songList: nil,
+
+        memberList: [],
+        introduction: nil,
+
+        snsList: nil
+    )
+}
+

--- a/GetARock/GetARock/Global/Utils/ModelData.swift
+++ b/GetARock/GetARock/Global/Utils/ModelData.swift
@@ -7,10 +7,10 @@
 
 struct ModelData {
     static var bandCreationData: BandInformationDTO = BandInformationDTO(
-        name: "",
-        address: Address(city: "",
-                         street: "",
-                         detail: "",
+        name: "user",
+        address: Address(city: "default",
+                         street: "default",
+                         detail: "default",
                          longitude: 0.0,
                          latitude: 0.0),
 

--- a/GetARock/GetARock/Screens/BandCreation/BandMemberAddViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/BandMemberAddViewController.swift
@@ -7,12 +7,16 @@
 
 import UIKit
 
-class BandMemberAddViewController: UIViewController {
+final class BandMemberAddViewController: UIViewController {
 
      override func viewDidLoad() {
          super.viewDidLoad()
+         setupLayout()
          attribute()
      }
+    
+    private func setupLayout() {
+    }
     
     private func attribute() {
         self.view.backgroundColor = .white

--- a/GetARock/GetARock/Screens/BandCreation/BandMemberAddViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/BandMemberAddViewController.swift
@@ -1,0 +1,22 @@
+//
+//  BandMemberAddViewController.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/02/13.
+//
+
+import UIKit
+
+class BandMemberAddViewController: UIViewController {
+
+     override func viewDidLoad() {
+         super.viewDidLoad()
+         attribute()
+     }
+    
+    private func attribute() {
+        self.view.backgroundColor = .white
+    }
+
+ }
+

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
@@ -9,7 +9,7 @@ import UIKit
 
 final class LeaderPositionSelectHeaderView: UIView {
     
-    private let pageIndicatorLabel = BasicLabel(contentText: "1/3", fontStyle: .subTitle, textColorInfo: .gray02)
+    private let pageIndicatorLabel = BasicLabel(contentText: "1/3", fontStyle: .headline03, textColorInfo: .gray02)
     
     //TODO: 추후 유저 데이터를 이용해 이름을 유저에 맞게 업데이트해야함
     private let titleLabel: BasicLabel = {

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
@@ -1,0 +1,50 @@
+//
+//  LeaderPositionSelectHeaderView.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/02/12.
+//
+
+import UIKit
+
+final class LeaderPositionSelectHeaderView: UIView {
+    
+    private let pageIndicatorLabel = BasicLabel(contentText: "1/3", fontStyle: .subTitle, textColorInfo: .gray02)
+    
+    private let titleLabel: BasicLabel = {
+        $0.numberOfLines = 3
+        return $0
+    }(BasicLabel(contentText: "00님의\n밴드에서포지션을\n알려주세요.", fontStyle: .largeTitle01, textColorInfo: .white))
+    
+    private let subTitleLabel = BasicLabel(contentText: "최대 2개까지 선택 가능합니다.", fontStyle: .subTitle, textColorInfo: .gray02)
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupLayout() {
+        self.addSubview(pageIndicatorLabel)
+        pageIndicatorLabel.constraint(top: self.topAnchor,
+                                      leading: self.leadingAnchor,
+                                      trailing: self.trailingAnchor,
+                                      padding: UIEdgeInsets(top: 20, left: 17, bottom: 0, right: 0))
+        
+        self.addSubview(titleLabel)
+        titleLabel.constraint(top: pageIndicatorLabel.bottomAnchor,
+                              leading: self.leadingAnchor,
+                              trailing: self.trailingAnchor,
+                              padding: UIEdgeInsets(top: 6, left: 16, bottom: 0, right: 16))
+        
+        self.addSubview(subTitleLabel)
+        subTitleLabel.constraint(top: titleLabel.bottomAnchor,
+                                 leading: self.leadingAnchor,
+                                 bottom: self.bottomAnchor,
+                                 trailing: self.trailingAnchor,
+                                 padding: UIEdgeInsets(top: 10, left: 16, bottom: 49, right: 16))
+    }
+}

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
@@ -35,19 +35,19 @@ final class LeaderPositionSelectHeaderView: UIView {
         pageIndicatorLabel.constraint(top: self.topAnchor,
                                       leading: self.leadingAnchor,
                                       trailing: self.trailingAnchor,
-                                      padding: UIEdgeInsets(top: 20, left: 17, bottom: 0, right: 0))
+                                      padding: UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0))
         
         self.addSubview(titleLabel)
         titleLabel.constraint(top: pageIndicatorLabel.bottomAnchor,
                               leading: self.leadingAnchor,
                               trailing: self.trailingAnchor,
-                              padding: UIEdgeInsets(top: 6, left: 16, bottom: 0, right: 16))
+                              padding: UIEdgeInsets(top: 6, left: 0, bottom: 0, right: 0))
         
         self.addSubview(subTitleLabel)
         subTitleLabel.constraint(top: titleLabel.bottomAnchor,
                                  leading: self.leadingAnchor,
                                  bottom: self.bottomAnchor,
                                  trailing: self.trailingAnchor,
-                                 padding: UIEdgeInsets(top: 10, left: 16, bottom: 49, right: 16))
+                                 padding: UIEdgeInsets(top: 10, left: 0, bottom: 49, right: 0))
     }
 }

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
@@ -11,6 +11,7 @@ final class LeaderPositionSelectHeaderView: UIView {
     
     private let pageIndicatorLabel = BasicLabel(contentText: "1/3", fontStyle: .subTitle, textColorInfo: .gray02)
     
+    //TODO: 추후 유저 데이터를 이용해 이름을 유저에 맞게 업데이트해야함
     private let titleLabel: BasicLabel = {
         $0.numberOfLines = 3
         return $0

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
@@ -13,9 +13,9 @@ final class LeaderPositionSelectHeaderView: UIView {
     
     //TODO: 추후 유저 데이터를 이용해 이름을 유저에 맞게 업데이트해야함
     private let titleLabel: BasicLabel = {
-        $0.numberOfLines = 3
+        $0.numberOfLines = 2
         return $0
-    }(BasicLabel(contentText: "00님의\n밴드에서포지션을\n알려주세요.", fontStyle: .largeTitle01, textColorInfo: .white))
+    }(BasicLabel(contentText: "루키님은 밴드에서\n어떤 포지션인가요?", fontStyle: .largeTitle01, textColorInfo: .white))
     
     private let subTitleLabel: BasicLabel = BasicLabel(contentText: "최대 2개까지 선택 가능합니다.",
                                                        fontStyle: .subTitle,

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectHeaderView.swift
@@ -17,7 +17,9 @@ final class LeaderPositionSelectHeaderView: UIView {
         return $0
     }(BasicLabel(contentText: "00님의\n밴드에서포지션을\n알려주세요.", fontStyle: .largeTitle01, textColorInfo: .white))
     
-    private let subTitleLabel = BasicLabel(contentText: "최대 2개까지 선택 가능합니다.", fontStyle: .subTitle, textColorInfo: .gray02)
+    private let subTitleLabel: BasicLabel = BasicLabel(contentText: "최대 2개까지 선택 가능합니다.",
+                                                       fontStyle: .subTitle,
+                                                       textColorInfo: .gray02)
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -10,10 +10,6 @@ import UIKit
 final class LeaderPositionSelectViewController: UIViewController {
     
     //MARK: Properties
-    
-    // 최종적으로 보내야하는 데이터 양식입니다. 이 데이터를 계속 전달하기보다는
-    // 전역변수로 하나의 인스턴스로 만들어서 공유한다
-    // 왜냐면 각각의 뷰컨에서 네비게이션 될 때마다 바뀐 데이터를 전달하는게 번거롭다
     private var bandCreationData = BasicDataModel.bandCreationData
     
     private var memberList: [MemberList] = []
@@ -136,8 +132,6 @@ extension LeaderPositionSelectViewController {
         let bandLeader: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
         
         self.memberList.append(bandLeader)
-        // append로 처리할 수 있으나 대체하는 것이 좋다고 생각
-        // 왜냐면 다시 이전으로 네비게이션되었을 때 수정하면 데이터 자체가 통쨰로 바꿔야되니까
         self.bandCreationData.memberList = self.memberList
         //MARK: Merge 전 삭제 필요
         print(self.bandCreationData)

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -1,0 +1,117 @@
+//
+//  LeaderPositionSelectViewController.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/02/12.
+//
+
+import UIKit
+
+final class LeaderPositionSelectViewController: UIViewController {
+    
+    private var positions: [Item] = [
+        .position(Position(instrumentName: "보컬", instrumentImageName: .vocal, isETC: false)),
+        .position(Position(instrumentName: "기타", instrumentImageName: .guitar, isETC: false)),
+        .position(Position(instrumentName: "키보드", instrumentImageName: .keyboard, isETC: false)),
+        .position(Position(instrumentName: "드럼", instrumentImageName: .drum, isETC: false)),
+        .position(Position(instrumentName: "베이스", instrumentImageName: .bass, isETC: false)),
+        .plusPosition
+    ]
+    
+    private lazy var positionCollectionView = PositionCollectionView(
+        cellType: .position,
+        items: positions,
+        isNeedHeader: true,
+        headerView: LeaderPositionSelectHeaderView()
+    )
+    
+    private let nextButton: BottomButton = {
+        $0.setTitle("다음", for: .normal)
+        return $0
+    }(BottomButton())
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupLayout()
+        attribute()
+        configureDelegate()
+        addObservePositionPlusButtonTapped()
+        addObservePositionDeleteButtonTapped()
+    }
+    
+    private func attribute() {
+        self.view.backgroundColor = .dark01
+    }
+    
+    private func configureDelegate() {
+        positionCollectionView.delegate = self
+    }
+    
+    private func addObservePositionPlusButtonTapped() {
+         NotificationCenter.default.addObserver(self,
+                                                selector: #selector(showPositionPlusModal),
+                                                name: Notification.Name(StringLiteral.showPositionPlusModal),
+                                                object: nil)
+     }
+    
+    @objc
+    private func showPositionPlusModal() {
+        let viewController = PlusPositionViewController()
+        viewController.delegate = self
+        present(viewController, animated: true)
+    }
+    
+    private func addObservePositionDeleteButtonTapped() {
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(deletePosition(_:)),
+                                               name: Notification.Name(StringLiteral.deletePositionCell),
+                                               object: nil)
+    }
+    
+    @objc
+    private func deletePosition(_ notification: Notification) {
+        guard let deleteIndexPath = notification.userInfo?["index"] as? Int else { return }
+        positions.remove(at: deleteIndexPath)
+        self.positionCollectionView.applySnapshot(with: positions)
+        self.updateDataSourceIndex(from: deleteIndexPath, endIndex: positions.count - 1)
+    }
+    
+    private func updateDataSourceIndex(from startIndex: Int, endIndex: Int) {
+        for index in startIndex..<endIndex {
+            positionCollectionView.updateCellIndex(at: IndexPath(item: index, section: 0))
+        }
+    }
+    
+    private func setupLayout() {
+        self.view.addSubview(positionCollectionView)
+        self.view.addSubview(nextButton)
+        
+        positionCollectionView.constraint(top: view.safeAreaLayoutGuide.topAnchor,
+                                          leading: view.leadingAnchor,
+                                          bottom: nextButton.topAnchor,
+                                          trailing: view.trailingAnchor,
+                                          padding: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16))
+        
+        
+        nextButton.constraint(bottom: view.bottomAnchor,
+                              centerX: view.centerXAnchor,
+                              padding: UIEdgeInsets(top: 0, left: 0, bottom: 42, right: 0))
+    }
+}
+
+extension LeaderPositionSelectViewController: PositionCollectionViewDelegate {
+    func canSelectPosition(_ collectionView: UICollectionView, indexPath: IndexPath, selectedItemsCount: Int) -> Bool {
+        return true
+    }
+}
+
+extension LeaderPositionSelectViewController: PlusPositionViewControllerDelegate {
+    func addPosition(instrumentName: String) {
+        let newPosition: Item = .position(Position(instrumentName: instrumentName,
+                                                   instrumentImageName: .etc,
+                                                   isETC: true))
+        positions.insert(newPosition, at: positions.count - 1)
+        self.positionCollectionView.applySnapshot(with: positions)
+    }
+}
+

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -14,7 +14,7 @@ final class LeaderPositionSelectViewController: UIViewController {
     // 최종적으로 보내야하는 데이터 양식입니다. 이 데이터를 계속 전달하기보다는
     // 전역변수로 하나의 인스턴스로 만들어서 공유한다
     // 왜냐면 각각의 뷰컨에서 네비게이션 될 때마다 바뀐 데이터를 전달하는게 번거롭다
-    private var bandCreationData = ModelData.bandCreationData
+    private var bandCreationData = BasicDataModel.bandCreationData
     
     private var memberList: [MemberList] = []
     

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -9,11 +9,15 @@ import UIKit
 
 final class LeaderPositionSelectViewController: UIViewController {
     
-    //MARK: Properties
+    //MARK: - Property
+    
     private var bandCreationData = BasicDataModel.bandCreationData
     
     private var memberList: [MemberList] = []
     
+    //MARK: - View
+    
+    //TODO: 추후 유저 데이터에서 유저가 가능하다고 응답한 악기들로 대체되어야함.
     private var positions: [Item] = [
         .position(Position(instrumentName: "보컬", instrumentImageName: .vocal, isETC: false)),
         .position(Position(instrumentName: "기타", instrumentImageName: .guitar, isETC: false)),
@@ -39,7 +43,7 @@ final class LeaderPositionSelectViewController: UIViewController {
         return $0
     }(BottomButton())
     
-    //MARK: LifeCycles
+    //MARK: - Life Cycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -51,6 +55,8 @@ final class LeaderPositionSelectViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         self.navigationController?.navigationBar.isHidden = true
     }
+    
+    //MARK: - Method
     
     private func attribute() {
         self.view.backgroundColor = .dark01
@@ -88,10 +94,17 @@ extension LeaderPositionSelectViewController {
         let selectedInstruments: [InstrumentList] = self.positionCollectionView.getSelectedInstruments()
         //TODO: 추후 밴드를 생성하려는 유저의 닉네임으로 바꿔야함
         let firstMember: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
-        self.memberList.append(firstMember)
+        if self.memberList.isEmpty {
+            self.memberList.append(firstMember)
+        } else {
+            self.memberList.removeAll(keepingCapacity: true)
+            self.memberList.append(firstMember)
+        }
         self.bandCreationData.memberList = self.memberList
         //MARK: Merge 전 삭제 필요
         print(self.bandCreationData)
+        print("======================")
+        print(self.memberList.count)
     }
     
     private func navigateToNext() {
@@ -105,18 +118,5 @@ extension LeaderPositionSelectViewController: PositionCollectionViewDelegate {
     func canSelectPosition(_ collectionView: UICollectionView, indexPath: IndexPath, selectedItemsCount: Int) -> Bool {
         if selectedItemsCount > 1 { return false }
         return true
-    }
-}
-
-extension PositionCollectionView {
-    func getSelectedInstruments() -> [InstrumentList] {
-        var selectedInstruments: [InstrumentList] = []
-        let selectedIndexPaths = self.collectionView.indexPathsForSelectedItems ?? []
-        
-        for indexPath in selectedIndexPaths {
-            guard let cell =  self.collectionView.cellForItem(at: indexPath) as? PositionCollectionViewCell else { return [] }
-            selectedInstruments.append(InstrumentList(name: cell.positionNameLabel.text ?? ""))
-        }
-        return selectedInstruments
     }
 }

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -18,7 +18,7 @@ final class LeaderPositionSelectViewController: UIViewController {
         .plusPosition
     ]
     
-    private lazy var positionCollectionView = PositionCollectionView(
+    private lazy var positionCollectionView: PositionCollectionView = PositionCollectionView(
         cellType: .position,
         items: positions,
         isNeedHeader: true,

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -8,6 +8,27 @@
 import UIKit
 
 final class LeaderPositionSelectViewController: UIViewController {
+
+    let bandInfo = BandInformationDTO(
+        name: "",
+        address: Address(city: "",
+                         street: "",
+                         detail: "",
+                         longitude: 0.0,
+                         latitude: 0.0),
+
+        songList: nil,
+
+        memberList: [MemberList(memberId: 1,
+                                name: "",
+                                memberState: .inviting,
+                                instrumentList:
+                                    [InstrumentList(name: .base)]
+                               )],
+        introduction: nil,
+
+        snsList: nil
+    )
     
     private var positions: [Item] = [
         .position(Position(instrumentName: "보컬", instrumentImageName: .vocal, isETC: false)),

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -129,9 +129,9 @@ extension LeaderPositionSelectViewController {
         }
         
         //TODO: 추후 밴드를 생성하려는 유저의 닉네임으로 바꿔야함
-        let bandLeader: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
+        let firstMember: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
         
-        self.memberList.append(bandLeader)
+        self.memberList.append(firstMember)
         self.bandCreationData.memberList = self.memberList
         //MARK: Merge 전 삭제 필요
         print(self.bandCreationData)

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -8,14 +8,14 @@
 import UIKit
 
 final class LeaderPositionSelectViewController: UIViewController {
-
+    
     //MARK: Properties
-
+    
     // 최종적으로 보내야하는 데이터 양식입니다. 이 데이터를 계속 전달하기보다는
     // 전역변수로 하나의 인스턴스로 만들어서 공유한다
     // 왜냐면 각각의 뷰컨에서 네비게이션 될 때마다 바뀐 데이터를 전달하는게 번거롭다
     private var bandCreationData = ModelData.bandCreationData
-
+    
     private var memberList: [MemberList] = []
     
     private var positions: [Item] = [
@@ -38,6 +38,7 @@ final class LeaderPositionSelectViewController: UIViewController {
         $0.setTitle("다음", for: .normal)
         let action = UIAction { _ in
             self.addSelectedPositionData()
+            self.navigateToNext()
         }
         $0.addAction(action, for: .touchUpInside)
         return $0
@@ -54,6 +55,10 @@ final class LeaderPositionSelectViewController: UIViewController {
         addObservePositionDeleteButtonTapped()
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
     private func attribute() {
         self.view.backgroundColor = .dark01
     }
@@ -63,11 +68,11 @@ final class LeaderPositionSelectViewController: UIViewController {
     }
     
     private func addObservePositionPlusButtonTapped() {
-         NotificationCenter.default.addObserver(self,
-                                                selector: #selector(showPositionPlusModal),
-                                                name: Notification.Name(StringLiteral.showPositionPlusModal),
-                                                object: nil)
-     }
+        NotificationCenter.default.addObserver(self,
+                                               selector: #selector(showPositionPlusModal),
+                                               name: Notification.Name(StringLiteral.showPositionPlusModal),
+                                               object: nil)
+    }
     
     @objc
     private func showPositionPlusModal() {
@@ -121,20 +126,26 @@ extension LeaderPositionSelectViewController {
         for index in 0..<self.positions.count - 1 {
             
             guard let cell =  self.positionCollectionView.collectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? PositionCollectionViewCell else { return }
-
+            
             if cell.isSelected {
                 selectedInstruments.append(InstrumentList(name: cell.positionNameLabel.text ?? ""))
             }
         }
-
+        
         //TODO: 추후 밴드를 생성하려는 유저의 닉네임으로 바꿔야함
         let bandLeader: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
-
+        
         self.memberList.append(bandLeader)
         // append로 처리할 수 있으나 대체하는 것이 좋다고 생각
         // 왜냐면 다시 이전으로 네비게이션되었을 때 수정하면 데이터 자체가 통쨰로 바꿔야되니까
         self.bandCreationData.memberList = self.memberList
+        //MARK: Merge 전 삭제 필요
         print(self.bandCreationData)
+    }
+    
+    private func navigateToNext() {
+        self.navigationController?.pushViewController(BandMemberAddViewController(), animated: true)
+        self.navigationController?.navigationBar.isHidden = false
     }
 }
 

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -39,17 +39,18 @@ final class LeaderPositionSelectViewController: UIViewController {
         let action = UIAction { _ in
 
             var selectedInstruments: [InstrumentList] = []
-            //MARK: 선택된 Cell은 데이터모델에 추가
-            for index in 0..<self.positions.count {
-
+            //MARK: collectionView에서 선택된 Cell만 데이터에 추가
+            for index in 0..<self.positions.count - 1 {
+                
                 guard let cell =  self.positionCollectionView.collectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? PositionCollectionViewCell else { return }
 
-                if !cell.isSelected {
+                if cell.isSelected {
                     selectedInstruments.append(InstrumentList(name: cell.positionNameLabel.text ?? ""))
                 }
             }
 
-            let bandLeader: MemberList = MemberList(memberId: 0, name: "루키", memberState: .admin, instrumentList: selectedInstruments)
+            //TODO: 추후 밴드를 생성하려는 유저의 닉네임으로 바꿔야함
+            let bandLeader: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
 
             self.memberList.append(bandLeader)
             // append로 처리할 수 있으나 대체하는 것이 좋다고 생각
@@ -60,6 +61,8 @@ final class LeaderPositionSelectViewController: UIViewController {
         $0.addAction(action, for: .touchUpInside)
         return $0
     }(BottomButton())
+    
+    //MARK: LifeCycles
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -101,6 +101,7 @@ final class LeaderPositionSelectViewController: UIViewController {
 
 extension LeaderPositionSelectViewController: PositionCollectionViewDelegate {
     func canSelectPosition(_ collectionView: UICollectionView, indexPath: IndexPath, selectedItemsCount: Int) -> Bool {
+        if selectedItemsCount > 1 { return false }
         return true
     }
 }

--- a/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift
@@ -37,26 +37,7 @@ final class LeaderPositionSelectViewController: UIViewController {
     private lazy var nextButton: BottomButton = {
         $0.setTitle("다음", for: .normal)
         let action = UIAction { _ in
-
-            var selectedInstruments: [InstrumentList] = []
-            //MARK: collectionView에서 선택된 Cell만 데이터에 추가
-            for index in 0..<self.positions.count - 1 {
-                
-                guard let cell =  self.positionCollectionView.collectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? PositionCollectionViewCell else { return }
-
-                if cell.isSelected {
-                    selectedInstruments.append(InstrumentList(name: cell.positionNameLabel.text ?? ""))
-                }
-            }
-
-            //TODO: 추후 밴드를 생성하려는 유저의 닉네임으로 바꿔야함
-            let bandLeader: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
-
-            self.memberList.append(bandLeader)
-            // append로 처리할 수 있으나 대체하는 것이 좋다고 생각
-            // 왜냐면 다시 이전으로 네비게이션되었을 때 수정하면 데이터 자체가 통쨰로 바꿔야되니까
-            self.bandCreationData.memberList = self.memberList
-            print(self.bandCreationData)
+            self.addSelectedPositionData()
         }
         $0.addAction(action, for: .touchUpInside)
         return $0
@@ -130,6 +111,30 @@ final class LeaderPositionSelectViewController: UIViewController {
         nextButton.constraint(bottom: view.bottomAnchor,
                               centerX: view.centerXAnchor,
                               padding: UIEdgeInsets(top: 0, left: 0, bottom: 42, right: 0))
+    }
+}
+
+extension LeaderPositionSelectViewController {
+    //MARK: collectionView에서 선택된 Cell만 데이터에 추가
+    private func addSelectedPositionData() {
+        var selectedInstruments: [InstrumentList] = []
+        for index in 0..<self.positions.count - 1 {
+            
+            guard let cell =  self.positionCollectionView.collectionView.cellForItem(at: IndexPath(row: index, section: 0)) as? PositionCollectionViewCell else { return }
+
+            if cell.isSelected {
+                selectedInstruments.append(InstrumentList(name: cell.positionNameLabel.text ?? ""))
+            }
+        }
+
+        //TODO: 추후 밴드를 생성하려는 유저의 닉네임으로 바꿔야함
+        let bandLeader: MemberList = MemberList(memberId: 0, name: "user", memberState: .admin, instrumentList: selectedInstruments)
+
+        self.memberList.append(bandLeader)
+        // append로 처리할 수 있으나 대체하는 것이 좋다고 생각
+        // 왜냐면 다시 이전으로 네비게이션되었을 때 수정하면 데이터 자체가 통쨰로 바꿔야되니까
+        self.bandCreationData.memberList = self.memberList
+        print(self.bandCreationData)
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
- closed #82 

## 배경
유저가 밴드를 생성할 때, 가장 먼저 어떤 포지션을 맡을지 최대 2개까지 선택할 수 있습니다. 그와 관련된 UI와 기능을 구현합니다.

<img width="300" alt="image" src="https://user-images.githubusercontent.com/103009135/218488934-06c16cfe-039d-4f39-a62a-17309c095d09.png">


## 작업 내용

## ➕ 추가된 class 및 struct
### 1. LeaderPositionSelectViewController, LeaderPositionSelectHeaderView
- 기본UI와 관련된 클래스로 데이크가 이전에 작업해주신 PositionSelectViewController 구조를 사용했습니다👍 [PR#74](https://github.com/extreme-rock/GetARock-iOS/pull/74)
- HeaderView를 따로 만들어서 init시 넣어주었고 일부UILabel은 BasicLabel로 대체되었습니다.

- 추가로 데이크가 만든 델리게이트 패턴을 채택해서 포지션 최대 선택 개수를 제한하였습니다.

https://github.com/extreme-rock/GetARock-iOS/blob/3358721cc3881160e0bcd866b31b0163fe146a78/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift#L146-L152
</br>

### 2. BandInformationDTO
- 밴드 생성 후 관련 데이터를 서버에 json형태로 보내야합니다. 그러기 위해서 먼저 struct로 데이터 모델을 잡은 뒤에 인코딩 작업을 하게 됩니다.
- 일반적으로 DTO(Data Transfer Object)라고 하기에 BandInformationDTO로 네이밍했습니다. 

https://github.com/extreme-rock/GetARock-iOS/blob/3358721cc3881160e0bcd866b31b0163fe146a78/GetARock/GetARock/Global/Network/Model/BandInformationDTO.swift#L10-L56
</br>

### 3. BasicDataModel
- 우리가 보내려는 밴드 데이터의 기본형태를 담고 있는 구조체입니다. 
밴드를 생성하는데는 밴드 구성원, 리더정보, 밴드 이름, 합주실 위치, 밴드 소개 등의 정보가 하나의 모델에 담겨서 서버로 POST 되어야합니다!

하지만 각각의 정보를 입력하는것은 여러 View Controller를 걸쳐서 진행되기 때문에 각각의 View Controller가 공통으로 접근할 수 있는 단일 인스턴스가 필요해서 만들게 되었습니다.

https://github.com/extreme-rock/GetARock-iOS/blob/3358721cc3881160e0bcd866b31b0163fe146a78/GetARock/GetARock/Global/Utils/BasicDataModel.swift#L8-L24

#### 각각의 정보를 입력함에 따라 모델 내의 프로퍼티를 하나하나 바꾸는 방식으로 진행할 예정입니다. 
</br>

### 4. BandMemberAddViewController 
- 추후 PR에서 작업할 밴드 구성원을 추가하는 VC 입니다. 네비게이션 테스트를 위해서 미리 파일만 만들어놓았습니다.
https://github.com/extreme-rock/GetARock-iOS/blob/3358721cc3881160e0bcd866b31b0163fe146a78/GetARock/GetARock/Screens/BandCreation/BandMemberAddViewController.swift#L10-L26
</br>

## 추가 메소드

### 1. addSelectedPositionData (LeaderPositionSelectViewController)
- collectionView에서 선택된 cell의 정보만 추출해서 밴드데이터에 추가하는 함수입니다.
- 자세한 사항은 코멘트에 달아놓았습니다

https://github.com/extreme-rock/GetARock-iOS/blob/3358721cc3881160e0bcd866b31b0163fe146a78/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift#L120-L138
</br>

### 2. navigateToNext  (LeaderPositionSelectViewController)
- 네비게이션과 관련한 메소드입니다. 네비게이션바의 숨김처리가 되어있습니다. 

https://github.com/extreme-rock/GetARock-iOS/blob/3358721cc3881160e0bcd866b31b0163fe146a78/GetARock/GetARock/Screens/BandCreation/LeaderPositionSelectViewController.swift#L140-L144


## 리뷰 노트
- 변수 네이밍 및 불필요한 코드
- 개선가능한 코드
- 데이터 모델의 적절성?

## 테스트 방법
SceneDelegate의 rootView를 아래와 같이 바꿔주세요

        window.rootViewController = UINavigationController(rootViewController: LeaderPositionSelectViewController())

## 스크린샷
<img width="300" alt="image" src="https://user-images.githubusercontent.com/103009135/218497802-fe2e278a-f1d2-49e8-9249-4a965417941d.png">

## UI Test
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/103009135/218623509-035722ec-4447-41f0-931a-329b51673d96.png">


<!--## 해당 PR 확정 사항-->
