### PR TITLE
[Feat] 선택된 포지션을 모두 선택 해제 해주는 버튼을 구현합니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -911,7 +911,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JP5BCXZWJP;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GetARock/Global/Supports/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -946,7 +946,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = JP5BCXZWJP;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GetARock/Global/Supports/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -911,7 +911,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = JP5BCXZWJP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GetARock/Global/Supports/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
@@ -946,7 +946,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = JP5BCXZWJP;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = GetARock/Global/Supports/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -8,16 +8,17 @@
 
 /* Begin PBXBuildFile section */
 		2A35EDA1F6F1B54EC4E9AEF0 /* Pods_GetARock_GetARockUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CDE4C1D1C0D8EC9E6B8B706 /* Pods_GetARock_GetARockUITests.framework */; };
-		4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */; };
-		4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */; };
 		4A00132B29835CF600EA992E /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A00132A29835CF600EA992E /* UIImage+Extension.swift */; };
 		4A08A9B4297BB0A300822FF9 /* PositionCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B3297BB0A300822FF9 /* PositionCollectionView.swift */; };
 		4A08A9B6297BC39000822FF9 /* PositionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B5297BC39000822FF9 /* PositionCollectionViewCell.swift */; };
 		4A08A9B8297C05F800822FF9 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B7297C05F800822FF9 /* NSObject+Extension.swift */; };
 		4A20270D2983FF410042EEFA /* NegativeDefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20270C2983FF410042EEFA /* NegativeDefaultButton.swift */; };
+		4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */; };
+		4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */; };
 		4A2027162987627E0042EEFA /* PositionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2027152987627E0042EEFA /* PositionSelectViewController.swift */; };
 		4A59318A2989041200C8DA31 /* PlusPositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5931892989041200C8DA31 /* PlusPositionViewController.swift */; };
 		4A59318C29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59318B29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift */; };
+		4A6A9A3C299DC2AD0039C0F7 /* Notification.Name+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A9A3B299DC2AC0039C0F7 /* Notification.Name+Extension.swift */; };
 		4ABFB6342988160D004BF232 /* PositionCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABFB6332988160D004BF232 /* PositionCollectionReusableView.swift */; };
 		4ABFB63629881959004BF232 /* PlusPositionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABFB63529881959004BF232 /* PlusPositionCollectionViewCell.swift */; };
 		4AC4CE3D297F7EED00BB823C /* BandMemberCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC4CE3C297F7EED00BB823C /* BandMemberCollectionViewCell.swift */; };
@@ -95,16 +96,17 @@
 		159F0019C5C9AB3A427BD907 /* Pods-GetARockTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetARockTests.release.xcconfig"; path = "Target Support Files/Pods-GetARockTests/Pods-GetARockTests.release.xcconfig"; sourceTree = "<group>"; };
 		1C72EC7590FAAB055CED6028 /* Pods-GetARockTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetARockTests.debug.xcconfig"; path = "Target Support Files/Pods-GetARockTests/Pods-GetARockTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2CDE4C1D1C0D8EC9E6B8B706 /* Pods_GetARock_GetARockUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetARock_GetARockUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPageSegmentedControl.swift; sourceTree = "<group>"; };
-		4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationPageSegmentedControl.swift; sourceTree = "<group>"; };
 		4A00132A29835CF600EA992E /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		4A08A9B3297BB0A300822FF9 /* PositionCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionView.swift; sourceTree = "<group>"; };
 		4A08A9B5297BC39000822FF9 /* PositionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A08A9B7297C05F800822FF9 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		4A20270C2983FF410042EEFA /* NegativeDefaultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NegativeDefaultButton.swift; sourceTree = "<group>"; };
+		4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPageSegmentedControl.swift; sourceTree = "<group>"; };
+		4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationPageSegmentedControl.swift; sourceTree = "<group>"; };
 		4A2027152987627E0042EEFA /* PositionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSelectViewController.swift; sourceTree = "<group>"; };
 		4A5931892989041200C8DA31 /* PlusPositionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPositionViewController.swift; sourceTree = "<group>"; };
 		4A59318B29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSelectCollectionViewHeader.swift; sourceTree = "<group>"; };
+		4A6A9A3B299DC2AC0039C0F7 /* Notification.Name+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Notification.Name+Extension.swift"; sourceTree = "<group>"; };
 		4ABFB6332988160D004BF232 /* PositionCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionReusableView.swift; sourceTree = "<group>"; };
 		4ABFB63529881959004BF232 /* PlusPositionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPositionCollectionViewCell.swift; sourceTree = "<group>"; };
 		4AC4CE3C297F7EED00BB823C /* BandMemberCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandMemberCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -125,7 +127,6 @@
 		7B76C5E72982D54100076637 /* SongListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongListCollectionViewCell.swift; sourceTree = "<group>"; };
 		7B7B04132988FC1100186986 /* SNSListStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSListStackView.swift; sourceTree = "<group>"; };
 		7B7B04152988FE9900186986 /* SNS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNS.swift; sourceTree = "<group>"; };
-
 		7BC2755D2987DF54008F4B9F /* BandButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandButtonView.swift; sourceTree = "<group>"; };
 		7BC2755F2987EA10008F4B9F /* emptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = emptyView.swift; sourceTree = "<group>"; };
 		7BC8E09C297C0BE6008FD5FE /* UIView+Gradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Gradation.swift"; sourceTree = "<group>"; };
@@ -375,6 +376,7 @@
 				4AC4CE48297FE16600BB823C /* UIButton+Extension.swift */,
 				4A00132A29835CF600EA992E /* UIImage+Extension.swift */,
 				A951F6522989EF6C00902CED /* String+Extension.swift */,
+				4A6A9A3B299DC2AC0039C0F7 /* Notification.Name+Extension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -728,6 +730,7 @@
 				7BC275602987EA10008F4B9F /* emptyView.swift in Sources */,
 				B88E1BA12977A70E006072B7 /* SceneDelegate.swift in Sources */,
 				B8B17C4F2980B67C00806899 /* Band.swift in Sources */,
+				4A6A9A3C299DC2AD0039C0F7 /* Notification.Name+Extension.swift in Sources */,
 				4A00132B29835CF600EA992E /* UIImage+Extension.swift in Sources */,
 				4AC4CE47297FDFB500BB823C /* BottomButton.swift in Sources */,
 				4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */,

--- a/GetARock/GetARock/Global/Extension/Notification.Name+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/Notification.Name+Extension.swift
@@ -1,0 +1,15 @@
+//
+//  Notification.Name+Extension.swift
+//  GetARock
+//
+//  Created by 최동권 on 2023/02/16.
+//
+
+import Foundation
+
+extension Notification.Name {
+    static let deletePositionCell = Notification.Name("deletePositionCell")
+    static let showPositionPlusModal = Notification.Name("showPositionPlusModal")
+    static let deselectAllPosition = Notification.Name("deselectAllPosition")
+    static let hideDeselectAllPositionButton = Notification.Name("hideDeselectAllPositionButton")
+}

--- a/GetARock/GetARock/Global/Literal/StringLiteral.swift
+++ b/GetARock/GetARock/Global/Literal/StringLiteral.swift
@@ -16,6 +16,7 @@ enum StringLiteral {
     static let deletePositionCell = "deletePositionCell"
     static let showPositionPlusModal = "showPositionPlusModal"
     static let deselectAllPosition = "deselectAllPosition"
+    static let hideDeselectAllPositionButton = "hideDeselectAllPositionButton"
 }
 
 enum InstrumentImageName: String {

--- a/GetARock/GetARock/Global/Literal/StringLiteral.swift
+++ b/GetARock/GetARock/Global/Literal/StringLiteral.swift
@@ -15,6 +15,7 @@ enum StringLiteral {
     // Notifiation.Name
     static let deletePositionCell = "deletePositionCell"
     static let showPositionPlusModal = "showPositionPlusModal"
+    static let deselectAllPosition = "deselectAllPosition"
 }
 
 enum InstrumentImageName: String {

--- a/GetARock/GetARock/Global/Literal/StringLiteral.swift
+++ b/GetARock/GetARock/Global/Literal/StringLiteral.swift
@@ -11,12 +11,6 @@ enum StringLiteral {
 //    static let exampleString = "안녕하세요"
     static let duplicationCheckPassed = "사용 가능해요"
     static let duplicationCheckUnPassed = "이미 사용하고 있어요"
-    
-    // Notifiation.Name
-    static let deletePositionCell = "deletePositionCell"
-    static let showPositionPlusModal = "showPositionPlusModal"
-    static let deselectAllPosition = "deselectAllPosition"
-    static let hideDeselectAllPositionButton = "hideDeselectAllPositionButton"
 }
 
 enum InstrumentImageName: String {

--- a/GetARock/GetARock/Global/Supports/SceneDelegate.swift
+++ b/GetARock/GetARock/Global/Supports/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = PositionSelectViewController()
+        window.rootViewController = LandingViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/GetARock/GetARock/Global/Supports/SceneDelegate.swift
+++ b/GetARock/GetARock/Global/Supports/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = LandingViewController()
+        window.rootViewController = PositionSelectViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/GetARock/GetARock/Global/UIComponent/BandMemberCollectionViewCell.swift
+++ b/GetARock/GetARock/Global/UIComponent/BandMemberCollectionViewCell.swift
@@ -63,7 +63,6 @@ final class BandMemberCollectionViewCell: UICollectionViewCell {
     private func setupLayout() {
         self.contentView.addSubview(containerView)
         self.containerView.constraint(to: contentView)
-        self.containerView.constraint(.widthAnchor, constant: CellSize.width)
         self.containerView.constraint(.heightAnchor, constant: 138)
         
         self.containerView.addSubview(positionImageView)

--- a/GetARock/GetARock/Global/UIComponent/PlusPositionCollectionViewCell.swift
+++ b/GetARock/GetARock/Global/UIComponent/PlusPositionCollectionViewCell.swift
@@ -28,7 +28,7 @@ final class PlusPositionCollectionViewCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupLayout()
-        addAction()
+        addActionToPlusButton()
     }
     
     required init?(coder: NSCoder) {
@@ -45,7 +45,7 @@ final class PlusPositionCollectionViewCell: UICollectionViewCell {
         self.plusPositionButton.constraint(to: self.containerView)
     }
     
-    private func addAction() {
+    private func addActionToPlusButton() {
         let action = UIAction { _ in
             NotificationCenter.default.post(name: Notification.Name(StringLiteral.showPositionPlusModal),
                                             object: nil)

--- a/GetARock/GetARock/Global/UIComponent/PlusPositionCollectionViewCell.swift
+++ b/GetARock/GetARock/Global/UIComponent/PlusPositionCollectionViewCell.swift
@@ -38,7 +38,6 @@ final class PlusPositionCollectionViewCell: UICollectionViewCell {
     private func setupLayout() {
         self.contentView.addSubview(containerView)
         self.containerView.constraint(to: self.contentView)
-        self.containerView.constraint(.widthAnchor, constant: CellSize.width)
         self.containerView.constraint(.heightAnchor, constant: 138)
         
         containerView.addSubview(plusPositionButton)

--- a/GetARock/GetARock/Global/UIComponent/PlusPositionCollectionViewCell.swift
+++ b/GetARock/GetARock/Global/UIComponent/PlusPositionCollectionViewCell.swift
@@ -47,7 +47,7 @@ final class PlusPositionCollectionViewCell: UICollectionViewCell {
     
     private func addActionToPlusButton() {
         let action = UIAction { _ in
-            NotificationCenter.default.post(name: Notification.Name(StringLiteral.showPositionPlusModal),
+            NotificationCenter.default.post(name: Notification.Name.showPositionPlusModal,
                                             object: nil)
         }
         self.plusPositionButton.addAction(action, for: .touchUpInside)

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -129,6 +129,13 @@ final class PositionCollectionView: UIView {
         guard let cell = collectionView.cellForItem(at: indexPath) as? PositionCollectionViewCell else { return }
         cell.cellIndex = indexPath.item
     }
+    
+    func deselectAllItem() {
+        let selectedIndexPath = self.collectionView.indexPathsForSelectedItems
+        selectedIndexPath?.forEach {
+            self.collectionView.deselectItem(at: $0, animated: true)
+        }
+    }
 }
 
 // MARK: - diffable

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -140,7 +140,7 @@ final class PositionCollectionView: UIView {
     
     private func postDeselectAllPositionButtonHiddenToggle() {
         NotificationCenter.default.post(
-            name: Notification.Name(StringLiteral.hideDeselectAllPositionButton),
+            name: Notification.Name.hideDeselectAllPositionButton,
             object: nil)
     }
 }

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -135,6 +135,13 @@ final class PositionCollectionView: UIView {
         selectedIndexPath?.forEach {
             self.collectionView.deselectItem(at: $0, animated: true)
         }
+        postDeselectAllPositionButtonHiddenToggle()
+    }
+    
+    private func postDeselectAllPositionButtonHiddenToggle() {
+        NotificationCenter.default.post(
+            name: Notification.Name(StringLiteral.hideDeselectAllPositionButton),
+            object: nil)
     }
 }
 
@@ -189,5 +196,18 @@ extension PositionCollectionView: UICollectionViewDelegate {
         guard let canSelect = delegate?.canSelectPosition(collectionView, indexPath: indexPath, selectedItemsCount: selectedPositionCount) else { return false }
         return canSelect
     }
-
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        let selectedCellCount = collectionView.indexPathsForSelectedItems?.count
+        if selectedCellCount == 1 {
+            postDeselectAllPositionButtonHiddenToggle()
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {
+        let selectedCellCount = collectionView.indexPathsForSelectedItems?.count
+        if selectedCellCount == 0 {
+            postDeselectAllPositionButtonHiddenToggle()
+        }
+    }
 }

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionViewCell.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionViewCell.swift
@@ -90,7 +90,6 @@ final class PositionCollectionViewCell: UICollectionViewCell {
     private func setupLayout() {
         self.contentView.addSubview(containerView)
         self.containerView.constraint(to: contentView)
-        self.containerView.constraint(.widthAnchor, constant: CellSize.width)
         self.containerView.constraint(.heightAnchor, constant: 138)
         
         self.containerView.addSubview(positionImageView)

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionViewCell.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionViewCell.swift
@@ -59,7 +59,7 @@ final class PositionCollectionViewCell: UICollectionViewCell {
     }()
     
     private lazy var action = UIAction { _ in
-        NotificationCenter.default.post(name: Notification.Name(StringLiteral.deletePositionCell),
+        NotificationCenter.default.post(name: Notification.Name.deletePositionCell,
                                         object: nil,
                                         userInfo: ["index": self.cellIndex as Any])
     }

--- a/GetARock/GetARock/Screens/Landing/LandingViewController.swift
+++ b/GetARock/GetARock/Screens/Landing/LandingViewController.swift
@@ -8,9 +8,25 @@
 import UIKit
 
 class LandingViewController: UIViewController {
-
+    
+    private let button = UIButton(type: .system)
+    
      override func viewDidLoad() {
          super.viewDidLoad()
+         button.setTitle("모달", for: .normal)
+         view.addSubview(button)
+         button.constraint(centerX: view.centerXAnchor,
+                           centerY: view.centerYAnchor)
+         addAction()
+         
      }
-
+    
+    func addAction() {
+        let action = UIAction { _ in
+            let vc = PositionSelectViewController()
+            vc.modalPresentationStyle = .fullScreen
+            self.present(vc, animated: true)
+        }
+        button.addAction(action, for: .touchUpInside)
+    }
  }

--- a/GetARock/GetARock/Screens/Landing/LandingViewController.swift
+++ b/GetARock/GetARock/Screens/Landing/LandingViewController.swift
@@ -9,24 +9,7 @@ import UIKit
 
 class LandingViewController: UIViewController {
     
-    private let button = UIButton(type: .system)
-    
      override func viewDidLoad() {
          super.viewDidLoad()
-         button.setTitle("모달", for: .normal)
-         view.addSubview(button)
-         button.constraint(centerX: view.centerXAnchor,
-                           centerY: view.centerYAnchor)
-         addAction()
-         
      }
-    
-    func addAction() {
-        let action = UIAction { _ in
-            let vc = PositionSelectViewController()
-            vc.modalPresentationStyle = .fullScreen
-            self.present(vc, animated: true)
-        }
-        button.addAction(action, for: .touchUpInside)
-    }
  }

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
@@ -36,8 +36,9 @@ final class PositionSelectCollectionViewHeader: UIView {
     
     private lazy var deselectAllPositionButton: UIButton = {
         $0.setTitle("전체 선택 해제", for: .normal)
+        $0.setTitleColor(.gray02, for: .normal)
         $0.titleLabel?.font = .setFont(.content)
-        $0.tintColor = .gray02
+        $0.isHidden = true
         let action = UIAction { _ in
             self.postDeselectAllPosition()
         }
@@ -50,6 +51,7 @@ final class PositionSelectCollectionViewHeader: UIView {
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupLayout()
+        addObserveHideDeselectAllPositionButton()
     }
     
     required init?(coder: NSCoder) {
@@ -57,6 +59,19 @@ final class PositionSelectCollectionViewHeader: UIView {
     }
     
     //MARK: - Method
+    
+    private func addObserveHideDeselectAllPositionButton() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(hideDeselectButton),
+            name: Notification.Name(StringLiteral.hideDeselectAllPositionButton),
+            object: nil)
+    }
+    
+    @objc
+    private func hideDeselectButton() {
+        self.deselectAllPositionButton.isHidden.toggle()
+    }
     
     private func setupLayout() {
         self.addSubview(pageIndicatorLabel)

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
@@ -58,6 +58,10 @@ final class PositionSelectCollectionViewHeader: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     //MARK: - Method
     
     private func addObserveHideDeselectAllPositionButton() {

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
@@ -64,7 +64,7 @@ final class PositionSelectCollectionViewHeader: UIView {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(hideDeselectButton),
-            name: Notification.Name(StringLiteral.hideDeselectAllPositionButton),
+            name: Notification.Name.hideDeselectAllPositionButton,
             object: nil)
     }
     
@@ -101,7 +101,7 @@ final class PositionSelectCollectionViewHeader: UIView {
     
     private func postDeselectAllPosition() {
         NotificationCenter.default.post(
-            name: Notification.Name(StringLiteral.deselectAllPosition),
+            name: Notification.Name.deselectAllPosition,
             object: nil)
     }
 }

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectCollectionViewHeader.swift
@@ -8,6 +8,9 @@
 import UIKit
 
 final class PositionSelectCollectionViewHeader: UIView {
+    
+    //MARK: - View
+    
     private let pageIndicatorLabel: UILabel = {
         $0.font = .setFont(.subTitle)
         $0.text = "1/3"
@@ -31,6 +34,19 @@ final class PositionSelectCollectionViewHeader: UIView {
         return $0
     }(UILabel())
     
+    private lazy var deselectAllPositionButton: UIButton = {
+        $0.setTitle("전체 선택 해제", for: .normal)
+        $0.titleLabel?.font = .setFont(.content)
+        $0.tintColor = .gray02
+        let action = UIAction { _ in
+            self.postDeselectAllPosition()
+        }
+        $0.addAction(action, for: .touchUpInside)
+        return $0
+    }(UIButton())
+    
+    //MARK: - Life Cycle
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupLayout()
@@ -39,6 +55,8 @@ final class PositionSelectCollectionViewHeader: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    //MARK: - Method
     
     private func setupLayout() {
         self.addSubview(pageIndicatorLabel)
@@ -56,8 +74,19 @@ final class PositionSelectCollectionViewHeader: UIView {
         self.addSubview(subTitleLabel)
         subTitleLabel.constraint(top: titleLabel.bottomAnchor,
                                  leading: self.leadingAnchor,
-                                 bottom: self.bottomAnchor,
                                  trailing: self.trailingAnchor,
-                                 padding: UIEdgeInsets(top: 10, left: 16, bottom: 49, right: 16))
+                                 padding: UIEdgeInsets(top: 10, left: 16, bottom: 0, right: 16))
+        
+        self.addSubview(deselectAllPositionButton)
+        deselectAllPositionButton.constraint(top: subTitleLabel.bottomAnchor,
+                                             bottom: self.bottomAnchor,
+                                             trailing: self.trailingAnchor,
+                                             padding: UIEdgeInsets(top: 15, left: 0, bottom: 11, right: 14))
+    }
+    
+    private func postDeselectAllPosition() {
+        NotificationCenter.default.post(
+            name: Notification.Name(StringLiteral.deselectAllPosition),
+            object: nil)
     }
 }

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
@@ -38,6 +38,10 @@ final class PositionSelectViewController: UIViewController {
         addAllObserver()
     }
     
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+    
     private func attribute() {
         self.view.backgroundColor = .dark01
     }

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
@@ -37,6 +37,7 @@ final class PositionSelectViewController: UIViewController {
         configureDelegate()
         addObservePositionPlusButtonTapped()
         addObservePositionDeleteButtonTapped()
+        addObserveDeselectAllPositionButtonTapped()
     }
     
     private func attribute() {
@@ -45,6 +46,19 @@ final class PositionSelectViewController: UIViewController {
     
     private func configureDelegate() {
         positionCollectionView.delegate = self
+    }
+    
+    private func addObserveDeselectAllPositionButtonTapped() {
+         NotificationCenter.default.addObserver(self,
+                                                selector: #selector(deselectAllPosition),
+                                                name: Notification.Name(StringLiteral.deselectAllPosition),
+                                                object: nil)
+     }
+    
+    
+    @objc
+    private func deselectAllPosition() {
+        self.positionCollectionView.deselectAllItem()
     }
     
     private func addObservePositionPlusButtonTapped() {

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
@@ -35,9 +35,7 @@ final class PositionSelectViewController: UIViewController {
         setupLayout()
         attribute()
         configureDelegate()
-        addObservePositionPlusButtonTapped()
-        addObservePositionDeleteButtonTapped()
-        addObserveDeselectAllPositionButtonTapped()
+        addAllObserver()
     }
     
     private func attribute() {
@@ -48,13 +46,19 @@ final class PositionSelectViewController: UIViewController {
         positionCollectionView.delegate = self
     }
     
-    private func addObserveDeselectAllPositionButtonTapped() {
-         NotificationCenter.default.addObserver(self,
-                                                selector: #selector(deselectAllPosition),
-                                                name: Notification.Name(StringLiteral.deselectAllPosition),
-                                                object: nil)
-     }
+    private func addAllObserver() {
+        addObservePositionPlusButtonTapped()
+        addObservePositionDeleteButtonTapped()
+        addObserveDeselectAllPositionButtonTapped()
+    }
     
+    private func addObserveDeselectAllPositionButtonTapped() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(deselectAllPosition),
+            name: Notification.Name(StringLiteral.deselectAllPosition),
+            object: nil)
+    }
     
     @objc
     private func deselectAllPosition() {
@@ -62,11 +66,12 @@ final class PositionSelectViewController: UIViewController {
     }
     
     private func addObservePositionPlusButtonTapped() {
-         NotificationCenter.default.addObserver(self,
-                                                selector: #selector(showPositionPlusModal),
-                                                name: Notification.Name(StringLiteral.showPositionPlusModal),
-                                                object: nil)
-     }
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(showPositionPlusModal),
+            name: Notification.Name(StringLiteral.showPositionPlusModal),
+            object: nil)
+    }
     
     @objc
     private func showPositionPlusModal() {
@@ -76,10 +81,11 @@ final class PositionSelectViewController: UIViewController {
     }
     
     private func addObservePositionDeleteButtonTapped() {
-        NotificationCenter.default.addObserver(self,
-                                               selector: #selector(deletePosition(_:)),
-                                               name: Notification.Name(StringLiteral.deletePositionCell),
-                                               object: nil)
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(deletePosition(_:)),
+            name: Notification.Name(StringLiteral.deletePositionCell),
+            object: nil)
     }
     
     @objc

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
@@ -56,7 +56,7 @@ final class PositionSelectViewController: UIViewController {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(deselectAllPosition),
-            name: Notification.Name(StringLiteral.deselectAllPosition),
+            name: Notification.Name.deselectAllPosition,
             object: nil)
     }
     
@@ -69,7 +69,7 @@ final class PositionSelectViewController: UIViewController {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(showPositionPlusModal),
-            name: Notification.Name(StringLiteral.showPositionPlusModal),
+            name: Notification.Name.showPositionPlusModal,
             object: nil)
     }
     
@@ -84,7 +84,7 @@ final class PositionSelectViewController: UIViewController {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(deletePosition(_:)),
-            name: Notification.Name(StringLiteral.deletePositionCell),
+            name: Notification.Name.deletePositionCell,
             object: nil)
     }
     

--- a/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
+++ b/GetARock/GetARock/Screens/SignUp/PositionSelectViewController.swift
@@ -50,13 +50,33 @@ final class PositionSelectViewController: UIViewController {
         positionCollectionView.delegate = self
     }
     
+    private func setupLayout() {
+        self.view.addSubview(positionCollectionView)
+        self.view.addSubview(nextButton)
+        
+        positionCollectionView.constraint(top: view.safeAreaLayoutGuide.topAnchor,
+                                          leading: view.leadingAnchor,
+                                          bottom: nextButton.topAnchor,
+                                          trailing: view.trailingAnchor,
+                                          padding: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16))
+        
+        
+        nextButton.constraint(bottom: view.bottomAnchor,
+                              centerX: view.centerXAnchor,
+                              padding: UIEdgeInsets(top: 0, left: 0, bottom: 42, right: 0))
+    }
+}
+
+//MARK: - observer 관련 Method
+
+extension PositionSelectViewController {
     private func addAllObserver() {
-        addObservePositionPlusButtonTapped()
-        addObservePositionDeleteButtonTapped()
-        addObserveDeselectAllPositionButtonTapped()
+        addObserveShowPositionPlusModal()
+        addObserveDelePositionCell()
+        addObserveDeselectAllPosition()
     }
     
-    private func addObserveDeselectAllPositionButtonTapped() {
+    private func addObserveDeselectAllPosition() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(deselectAllPosition),
@@ -69,7 +89,7 @@ final class PositionSelectViewController: UIViewController {
         self.positionCollectionView.deselectAllItem()
     }
     
-    private func addObservePositionPlusButtonTapped() {
+    private func addObserveShowPositionPlusModal() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(showPositionPlusModal),
@@ -84,7 +104,7 @@ final class PositionSelectViewController: UIViewController {
         present(viewController, animated: true)
     }
     
-    private func addObservePositionDeleteButtonTapped() {
+    private func addObserveDelePositionCell() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(deletePosition(_:)),
@@ -104,22 +124,6 @@ final class PositionSelectViewController: UIViewController {
         for index in startIndex..<endIndex {
             positionCollectionView.updateCellIndex(at: IndexPath(item: index, section: 0))
         }
-    }
-    
-    private func setupLayout() {
-        self.view.addSubview(positionCollectionView)
-        self.view.addSubview(nextButton)
-        
-        positionCollectionView.constraint(top: view.safeAreaLayoutGuide.topAnchor,
-                                          leading: view.leadingAnchor,
-                                          bottom: nextButton.topAnchor,
-                                          trailing: view.trailingAnchor,
-                                          padding: UIEdgeInsets(top: 10, left: 16, bottom: 10, right: 16))
-        
-        
-        nextButton.constraint(bottom: view.bottomAnchor,
-                              centerX: view.centerXAnchor,
-                              padding: UIEdgeInsets(top: 0, left: 0, bottom: 42, right: 0))
     }
 }
 


### PR DESCRIPTION
<!-- 불필요한 항목은 삭제해주세요 -->


## 관련 이슈
- Close #101 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경

<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용

### 📢 NotificationCenter를 이용하여 Selected된 cell을 모두 deselected해줍니다.

#### 1️⃣ DelegatePattern이 아니고 NotificationCenter를 이용한 이유

전체선택 해제 해주는 Button을 `PositionSelectCollectionViewHeader`에 구혔했는데요, 해당 뷰는 `PositionSelectViewController`에서 다음과 같이 넣어줍니다.
```Swift
    private lazy var positionCollectionView = PositionCollectionView(
        cellType: .position,
        items: positions,
        isNeedHeader: true,
        headerView: PositionSelectCollectionViewHeader()
    )
```
delegate패턴을 활용하기 위해서는 `PositionSelectCollectionViewHeader`를 따로 init해줘야하는 불필요한 과정이 필요하기 때문에
NotificationCenter를 이용하여 구현하였습니다.

#### 2️⃣ "전체 선택 해제" 버튼의 isHidden이 toggle되는 때
- 선택된 포지션 0개 : true
- 선택된 포지션 1개가 될 때 : false
- "전체 선택 해제"를 클릭했을 때 : false
deselect해주는 API인 `deselectItem(at: , animated: )`사용하면 UICollectionViewDelegate의 ` func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath)`부분이 자동으로 실행될줄 알았는데 그렇지 않아서,
`deselectAllItem()`이 실행될 때에도 toggle해주도록 하였습니다.
```Swift
    func deselectAllItem() {
        let selectedIndexPath = self.collectionView.indexPathsForSelectedItems
        selectedIndexPath?.forEach {
            self.collectionView.deselectItem(at: $0, animated: true)
        }
        postDeselectAllPositionButtonHiddenToggle()
    }
```

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 리뷰 노트
- NotificationCenter를 이용하는 과정에서의 문제점이 있을까요? 처음 써봤습니다..
- 변수명이 직과적인지?
<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->
- 모달로 해당 View를 띄웠을 때 전체 선택 해제 버튼의 노출이 의도적으로 되지 않는 에러가 있습니다. 해당 에러는 실제로 발생한 마이페이지 수정뷰에서 해결하겠습니다.
## 테스트 방법

<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 스크린샷
![Simulator Screen Recording - iPhone 14 Pro - 2023-02-14 at 18 59 02](https://user-images.githubusercontent.com/91456952/218702151-9c4c18b9-5ac2-4a76-8c60-f9a318de1843.gif)

<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->

<!--## 해당 PR 확정 사항-->

<!-- 해당 PR 리뷰 과정에서 논의된 확정 사항을 develop 브랜치에 머지하기 전 정리합니다. -->
