### PR TITLE
[Feat] UIPageViewController를 이용하여 마이페이지 수정VC의 틀을 잡았습니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -8,14 +8,17 @@
 
 /* Begin PBXBuildFile section */
 		2A35EDA1F6F1B54EC4E9AEF0 /* Pods_GetARock_GetARockUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2CDE4C1D1C0D8EC9E6B8B706 /* Pods_GetARock_GetARockUITests.framework */; };
-		4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */; };
-		4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */; };
 		4A00132B29835CF600EA992E /* UIImage+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A00132A29835CF600EA992E /* UIImage+Extension.swift */; };
 		4A08A9B4297BB0A300822FF9 /* PositionCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B3297BB0A300822FF9 /* PositionCollectionView.swift */; };
 		4A08A9B6297BC39000822FF9 /* PositionCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B5297BC39000822FF9 /* PositionCollectionViewCell.swift */; };
 		4A08A9B8297C05F800822FF9 /* NSObject+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A08A9B7297C05F800822FF9 /* NSObject+Extension.swift */; };
 		4A20270D2983FF410042EEFA /* NegativeDefaultButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20270C2983FF410042EEFA /* NegativeDefaultButton.swift */; };
+		4A20271129863D800042EEFA /* ModifyPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */; };
+		4A20271329865BEB0042EEFA /* InformationPageSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */; };
 		4A2027162987627E0042EEFA /* PositionSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2027152987627E0042EEFA /* PositionSelectViewController.swift */; };
+		4A268C63299A18660068F200 /* ModifyMyPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A268C62299A18660068F200 /* ModifyMyPageViewController.swift */; };
+		4A268C65299A187B0068F200 /* ModifyPositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A268C64299A187B0068F200 /* ModifyPositionViewController.swift */; };
+		4A268C67299A18B10068F200 /* ModifyUserProfileViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A268C66299A18B10068F200 /* ModifyUserProfileViewController.swift */; };
 		4A59318A2989041200C8DA31 /* PlusPositionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5931892989041200C8DA31 /* PlusPositionViewController.swift */; };
 		4A59318C29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A59318B29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift */; };
 		4ABFB6342988160D004BF232 /* PositionCollectionReusableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABFB6332988160D004BF232 /* PositionCollectionReusableView.swift */; };
@@ -95,14 +98,17 @@
 		159F0019C5C9AB3A427BD907 /* Pods-GetARockTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetARockTests.release.xcconfig"; path = "Target Support Files/Pods-GetARockTests/Pods-GetARockTests.release.xcconfig"; sourceTree = "<group>"; };
 		1C72EC7590FAAB055CED6028 /* Pods-GetARockTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GetARockTests.debug.xcconfig"; path = "Target Support Files/Pods-GetARockTests/Pods-GetARockTests.debug.xcconfig"; sourceTree = "<group>"; };
 		2CDE4C1D1C0D8EC9E6B8B706 /* Pods_GetARock_GetARockUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GetARock_GetARockUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPageSegmentedControl.swift; sourceTree = "<group>"; };
-		4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationPageSegmentedControl.swift; sourceTree = "<group>"; };
 		4A00132A29835CF600EA992E /* UIImage+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Extension.swift"; sourceTree = "<group>"; };
 		4A08A9B3297BB0A300822FF9 /* PositionCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionView.swift; sourceTree = "<group>"; };
 		4A08A9B5297BC39000822FF9 /* PositionCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionViewCell.swift; sourceTree = "<group>"; };
 		4A08A9B7297C05F800822FF9 /* NSObject+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSObject+Extension.swift"; sourceTree = "<group>"; };
 		4A20270C2983FF410042EEFA /* NegativeDefaultButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NegativeDefaultButton.swift; sourceTree = "<group>"; };
+		4A20271029863D800042EEFA /* ModifyPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPageSegmentedControl.swift; sourceTree = "<group>"; };
+		4A20271229865BEB0042EEFA /* InformationPageSegmentedControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InformationPageSegmentedControl.swift; sourceTree = "<group>"; };
 		4A2027152987627E0042EEFA /* PositionSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSelectViewController.swift; sourceTree = "<group>"; };
+		4A268C62299A18660068F200 /* ModifyMyPageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyMyPageViewController.swift; sourceTree = "<group>"; };
+		4A268C64299A187B0068F200 /* ModifyPositionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyPositionViewController.swift; sourceTree = "<group>"; };
+		4A268C66299A18B10068F200 /* ModifyUserProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModifyUserProfileViewController.swift; sourceTree = "<group>"; };
 		4A5931892989041200C8DA31 /* PlusPositionViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlusPositionViewController.swift; sourceTree = "<group>"; };
 		4A59318B29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionSelectCollectionViewHeader.swift; sourceTree = "<group>"; };
 		4ABFB6332988160D004BF232 /* PositionCollectionReusableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PositionCollectionReusableView.swift; sourceTree = "<group>"; };
@@ -125,7 +131,6 @@
 		7B76C5E72982D54100076637 /* SongListCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongListCollectionViewCell.swift; sourceTree = "<group>"; };
 		7B7B04132988FC1100186986 /* SNSListStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNSListStackView.swift; sourceTree = "<group>"; };
 		7B7B04152988FE9900186986 /* SNS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SNS.swift; sourceTree = "<group>"; };
-
 		7BC2755D2987DF54008F4B9F /* BandButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandButtonView.swift; sourceTree = "<group>"; };
 		7BC2755F2987EA10008F4B9F /* emptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = emptyView.swift; sourceTree = "<group>"; };
 		7BC8E09C297C0BE6008FD5FE /* UIView+Gradation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Gradation.swift"; sourceTree = "<group>"; };
@@ -218,6 +223,16 @@
 				4A59318B29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift */,
 			);
 			path = SignUp;
+			sourceTree = "<group>";
+		};
+		4A268C61299A18000068F200 /* ModifyMyPage */ = {
+			isa = PBXGroup;
+			children = (
+				4A268C62299A18660068F200 /* ModifyMyPageViewController.swift */,
+				4A268C64299A187B0068F200 /* ModifyPositionViewController.swift */,
+				4A268C66299A18B10068F200 /* ModifyUserProfileViewController.swift */,
+			);
+			path = ModifyMyPage;
 			sourceTree = "<group>";
 		};
 		4AC4CE3E297FB81E00BB823C /* Network */ = {
@@ -337,6 +352,7 @@
 		B88E1BCF2977A8CD006072B7 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				4A268C61299A18000068F200 /* ModifyMyPage */,
 				4A202714298761DA0042EEFA /* SignUp */,
 				B8468F62297A94B900A9E77E /* Maps */,
 				B88E1BE22977AE1D006072B7 /* Landing */,
@@ -697,6 +713,7 @@
 				9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */,
 				A96B8A0D2981714800905BC9 /* BasicLabel.swift in Sources */,
 				B88E1BD72977AB3D006072B7 /* ImageLiteral.swift in Sources */,
+				4A268C67299A18B10068F200 /* ModifyUserProfileViewController.swift in Sources */,
 				7BFE01A12982643E009608A2 /* Song.swift in Sources */,
 				B88E1BE52977AEC2006072B7 /* LandingViewController.swift in Sources */,
 				4AF5845A2978E497008F4068 /* UIView+Constraints.swift in Sources */,
@@ -711,6 +728,7 @@
 				4AC4CE41297FB85B00BB823C /* Position.swift in Sources */,
 				B8B17C522980B93300806899 /* Location.swift in Sources */,
 				7BC2755E2987DF54008F4B9F /* BandButtonView.swift in Sources */,
+				4A268C65299A187B0068F200 /* ModifyPositionViewController.swift in Sources */,
 				7B64C25B2983CFFE00E95911 /* SongListView.swift in Sources */,
 				4A59318C29896E7800C8DA31 /* PositionSelectCollectionViewHeader.swift in Sources */,
 				B88E1B9F2977A70E006072B7 /* AppDelegate.swift in Sources */,
@@ -745,6 +763,7 @@
 				7BC8E09D297C0BE6008FD5FE /* UIView+Gradation.swift in Sources */,
 				B8468F66297AD7CB00A9E77E /* MainMapViewController.swift in Sources */,
 				4AC4CE49297FE16600BB823C /* UIButton+Extension.swift in Sources */,
+				4A268C63299A18660068F200 /* ModifyMyPageViewController.swift in Sources */,
 				4AC4CE3D297F7EED00BB823C /* BandMemberCollectionViewCell.swift in Sources */,
 				B8B17C542980B99900806899 /* Coordinate.swift in Sources */,
 				4AC4CE4F2980BD3700BB823C /* SelectCollectionViewCell.swift in Sources */,

--- a/GetARock/GetARock/Global/Supports/SceneDelegate.swift
+++ b/GetARock/GetARock/Global/Supports/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = LandingViewController()
+        window.rootViewController = ModifyMyPageViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/GetARock/GetARock/Global/Supports/SceneDelegate.swift
+++ b/GetARock/GetARock/Global/Supports/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = ModifyMyPageViewController()
+        window.rootViewController = LandingViewController()
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
@@ -75,7 +75,6 @@ final class ModifyMyPageViewController: UIViewController {
     
     @objc
     private func segmentedControlValueChanged(_ sender: ModifyPageSegmentedControl) {
-        print(self.segmentedController.selectedSegmentIndex)
         currentPageNumber = self.segmentedController.selectedSegmentIndex
     }
 }

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
@@ -1,0 +1,84 @@
+//
+//  ModifyMyPageViewController.swift
+//  GetARock
+//
+//  Created by 최동권 on 2023/02/13.
+//
+
+import UIKit
+
+final class ModifyMyPageViewController: UIViewController {
+    
+    //MARK: - Property
+    
+    private let pageViewControllers: [UIViewController] = [ModifyPositionViewController(),
+                                                           ModifyUserProfileViewController()]
+    private var currentPageNumber: Int = 0 {
+        didSet {
+            let direction: UIPageViewController.NavigationDirection = oldValue <= self.currentPageNumber ? .forward : .reverse
+            self.pageViewController.setViewControllers(
+                [pageViewControllers[self.currentPageNumber]],
+                direction: direction,
+                animated: false
+            )
+        }
+    }
+    
+    //MARK: - View
+    
+    private lazy var segmentedController: ModifyPageSegmentedControl = {
+        $0.addTarget(self,
+                     action: #selector(segmentedControlValueChanged(_:)),
+                     for: .valueChanged)
+        return $0
+    }(ModifyPageSegmentedControl(items: ["포지션", "내 정보"]))
+    
+    private lazy var pageViewController: UIPageViewController = {
+        if let viewController = pageViewControllers.first {
+            $0.setViewControllers([viewController],
+                                  direction: .forward,
+                                  animated: true)
+        }
+       return $0
+    }(UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal))
+    
+   
+    
+    //MARK: - Life Cycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        attribute()
+        setupLayout()
+        // Do any additional setup after loading the view.
+    }
+    
+    //MARK: - Method
+    
+    private func attribute() {
+        self.view.backgroundColor = .dark01
+    }
+    
+    private func setupLayout() {
+        self.view.addSubview(segmentedController)
+        segmentedController.constraint(top: view.safeAreaLayoutGuide.topAnchor,
+                                       leading: view.leadingAnchor,
+                                       trailing: view.trailingAnchor,
+                                       padding: UIEdgeInsets(top: 25, left: 16, bottom: 0, right: 16))
+        segmentedController.constraint(.heightAnchor, constant: 50)
+        
+        self.view.addSubview(pageViewController.view)
+        pageViewController.view.constraint(top: segmentedController.bottomAnchor,
+                                           leading: view.leadingAnchor,
+                                           bottom: view.bottomAnchor,
+                                           trailing: view.trailingAnchor,
+                                           padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
+        
+    }
+    
+    @objc
+    private func segmentedControlValueChanged(_ sender: ModifyPageSegmentedControl) {
+        print(self.segmentedController.selectedSegmentIndex)
+        currentPageNumber = self.segmentedController.selectedSegmentIndex
+    }
+}

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
@@ -42,8 +42,6 @@ final class ModifyMyPageViewController: UIViewController {
        return $0
     }(UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal))
     
-   
-    
     //MARK: - Life Cycle
     
     override func viewDidLoad() {

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyMyPageViewController.swift
@@ -50,7 +50,6 @@ final class ModifyMyPageViewController: UIViewController {
         super.viewDidLoad()
         attribute()
         setupLayout()
-        // Do any additional setup after loading the view.
     }
     
     //MARK: - Method

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyPositionViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyPositionViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ModifyPositionViewController.swift
+//  GetARock
+//
+//  Created by 최동권 on 2023/02/13.
+//
+
+import UIKit
+
+final class ModifyPositionViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .red
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyPositionViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyPositionViewController.swift
@@ -11,19 +11,5 @@ final class ModifyPositionViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .red
-        // Do any additional setup after loading the view.
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyUserProfileViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyUserProfileViewController.swift
@@ -11,19 +11,5 @@ final class ModifyUserProfileViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.view.backgroundColor = .yellow
-        // Do any additional setup after loading the view.
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/GetARock/GetARock/Screens/ModifyMyPage/ModifyUserProfileViewController.swift
+++ b/GetARock/GetARock/Screens/ModifyMyPage/ModifyUserProfileViewController.swift
@@ -1,0 +1,29 @@
+//
+//  ModifyUserProfileViewController.swift
+//  GetARock
+//
+//  Created by 최동권 on 2023/02/13.
+//
+
+import UIKit
+
+final class ModifyUserProfileViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.view.backgroundColor = .yellow
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
<!-- 불필요한 항목은 삭제해주세요 -->


## 관련 이슈
- Close #93 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경

<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
### 📢 UIPageViewController와 UISegmentedControl을 활용하여 마이페이지 수정VC의 틀을 잡았습니다.

### 1️⃣ UIPageViewController
<img width="758" alt="스크린샷 2023-02-14 오후 7 13 16" src="https://user-images.githubusercontent.com/91456952/218705637-0e2bb62f-4dbf-4a81-b83c-198cd2029d47.png">
공식문서에 따르면 UIPageViewController는 자식 viewControllers 간의 navigation을 담당해주는 container viewController입니다.
그렇기 때문에 UIPageViewController 자체에 constraint를 줄 수 없습니다. 

> 그럼 어떻게 layout을 잡나요?
UIPageViewController는 ViewController을 상속받고 있기 때문에 view를 가집니다.
그래서 이 view에 autoLayout을 잡아주면 원하는 영역만큼 viewController를 띄워줄 수 있습니다.

아래 이미지는 `UIPageViewController().view`에 다음과 같이 layout을 줬을 때 보여지는 Hierarchy입니다.
```Swift
 self.view.addSubview(pageViewController.view)
        pageViewController.view.constraint(top: segmentedController.bottomAnchor,
                                           leading: view.leadingAnchor,
                                           bottom: view.bottomAnchor,
                                           trailing: view.trailingAnchor,
                                           padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0))
```
<img width="312" alt="스크린샷 2023-02-14 오후 7 28 26" src="https://user-images.githubusercontent.com/91456952/218709205-7a9dfdca-97f4-4266-980c-d61f69e975b1.png">

### 2️⃣ UIPageViewController와 UISegmentedControl 연결
현재 UIPageViewController에 보여지는 UIViewController의 번호를 나타내는  `private var currentPageNumber: Int`와 UISegmentedControl에서 선택된 segment의 Int값을 return하는 `segmentedController.selectedSegmentIndex` API를 이용하여 구현하였습니다.

`ModifyPageSegmentedControl`의 valueChanged가 감지되면 아래의 함수가 실행되어 currentPageNumber에 현재 선택된 segmented의 Index값을 넣어줍니다.
```Swift
    @objc
    private func segmentedControlValueChanged(_ sender: ModifyPageSegmentedControl) {
        print(self.segmentedController.selectedSegmentIndex)
        currentPageNumber = self.segmentedController.selectedSegmentIndex
    }
```

currentPageNumber는 didSet에서 새로 입력된 값을 바탕으로 `setViewController`를 실행합니다.
direction은 .forward, .reverse 두 가지가 있는데, animation의 방향을 결정합니다.
현재 UIPageViewController는 .horizontal .scroll 이므로 .forward는 -> 방향, .reverse는 <-방향으로의 애니메이션을 의미합니다.
```Swift
 private var currentPageNumber: Int = 0 {
        didSet {
            let direction: UIPageViewController.NavigationDirection = oldValue <= self.currentPageNumber ? .forward : .reverse
            self.pageViewController.setViewControllers(
                [pageViewControllers[self.currentPageNumber]],
                direction: direction,
                animated: false
            )
        }
    }
```

<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 리뷰 노트
- `setViewControllers`를 해줄 때 animation이 있는 것이 자연스러울 까요? 저는 저 커스텀된 segmentedControl이 View의 좌우를 꽉채우고 있지 않아서 animation이 없는 편이 자연스럽지 않나 라는 생각에 일단 animation을 false로 했습니다. 하위 VC를 모두 채우면 또 다른 생각이 들 수도 있을 것 같아요.. 

|animation: true|animation: false|
|:---|:---|
|![Simulator Screen Recording - iPhone 14 Pro - 2023-02-14 at 19 06 54](https://user-images.githubusercontent.com/91456952/218713865-6a3363e4-5dc3-45f6-8162-d29149454983.gif)|![Simulator Screen Recording - iPhone 14 Pro - 2023-02-14 at 19 06 14](https://user-images.githubusercontent.com/91456952/218713922-75e6d8c6-66a1-4899-8946-381fd2d4887c.gif)|

레퍼런스로 찾은 AppleMusic은 animation이 없는 버전을 사용하지만 자체적으로 fadeIn(?)하는 느낌의 애니메이션을 사용하는 것 같습니다.

https://user-images.githubusercontent.com/91456952/218714802-d436edc7-2121-4509-9d62-aa70a34838c6.MP4



<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->


## 테스트 방법
- 진입점을 `ModifyMyPageViewController()`로 바꿔주세요!
<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 스크린샷
리뷰 노트에 올린 gif로 대신하겠습니다.
<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->

<!--## 해당 PR 확정 사항-->

<!-- 해당 PR 리뷰 과정에서 논의된 확정 사항을 develop 브랜치에 머지하기 전 정리합니다. -->
