### PR TITLE
[Feat] 밴드 정보 입력 VC에서 합주곡을 추가하는 기능을 구현했습니다.

### DIFF
--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -72,6 +72,8 @@
 		9A3F07752987E1DB009CD500 /* TextLimitTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */; };
 		9A78BFE3298A9CD900953E4B /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE2298A9CD900953E4B /* NetworkError.swift */; };
 		9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */; };
+		9A82AF2F29B9FCBA0056315D /* PracticeSongBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A82AF2E29B9FCBA0056315D /* PracticeSongBoxView.swift */; };
+		9A82AF3229B9FD130056315D /* PracticeSongCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A82AF3129B9FD130056315D /* PracticeSongCardView.swift */; };
 		9AA0BB4F29A4E7FD00871A05 /* NotificationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0BB4E29A4E7FD00871A05 /* NotificationListViewController.swift */; };
 		9AA0BB5129A4E81700871A05 /* NotificationListVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0BB5029A4E81700871A05 /* NotificationListVO.swift */; };
 		9AA0BB5329A4E83400871A05 /* NotificationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0BB5229A4E83400871A05 /* NotificationTableViewCell.swift */; };
@@ -218,6 +220,8 @@
 		9A3F07742987E1DB009CD500 /* TextLimitTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextLimitTextField.swift; sourceTree = "<group>"; };
 		9A78BFE2298A9CD900953E4B /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicationCheckRequest.swift; sourceTree = "<group>"; };
+		9A82AF2E29B9FCBA0056315D /* PracticeSongBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeSongBoxView.swift; sourceTree = "<group>"; };
+		9A82AF3129B9FD130056315D /* PracticeSongCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeSongCardView.swift; sourceTree = "<group>"; };
 		9AA0BB4E29A4E7FD00871A05 /* NotificationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationListViewController.swift; sourceTree = "<group>"; };
 		9AA0BB5029A4E81700871A05 /* NotificationListVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationListVO.swift; sourceTree = "<group>"; };
 		9AA0BB5229A4E83400871A05 /* NotificationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTableViewCell.swift; sourceTree = "<group>"; };
@@ -414,6 +418,15 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		9A82AF3029B9FCC80056315D /* PracticeSongAddFlow */ = {
+			isa = PBXGroup;
+			children = (
+				9A82AF2E29B9FCBA0056315D /* PracticeSongBoxView.swift */,
+				9A82AF3129B9FD130056315D /* PracticeSongCardView.swift */,
+			);
+			path = PracticeSongAddFlow;
+			sourceTree = "<group>";
+		};
 		9AA0BB5429A4E94A00871A05 /* NotificationList */ = {
 			isa = PBXGroup;
 			children = (
@@ -431,6 +444,7 @@
 				9AFE014429990754004B0BCF /* LeaderPositionSelectHeaderView.swift */,
 				A97D579929B6F06700FEA49F /* BandInformationSetFlow */,
 				A96F3682299E2D2700376620 /* BandMemberAddFlow */,
+				9A82AF3029B9FCC80056315D /* PracticeSongAddFlow */,
 			);
 			path = BandCreation;
 			sourceTree = "<group>";
@@ -949,6 +963,7 @@
 				4A268C67299A18B10068F200 /* ModifyUserProfileViewController.swift in Sources */,
 				7BFE01A12982643E009608A2 /* Song.swift in Sources */,
 				7B6D3354299A2F76001FD630 /* BandDetailViewController.swift in Sources */,
+				9A82AF2F29B9FCBA0056315D /* PracticeSongBoxView.swift in Sources */,
 				B88E1BE52977AEC2006072B7 /* LandingViewController.swift in Sources */,
 				4AF5845A2978E497008F4068 /* UIView+Constraints.swift in Sources */,
 				4A4A6E9629A8F9CC005CF076 /* SignUpNetworkManager.swift in Sources */,
@@ -1002,6 +1017,7 @@
 				A96B8A0B2981706C00905BC9 /* BasicTextView.swift in Sources */,
 				9A29E6E8297E223A00D4A433 /* BasicComponentSize.swift in Sources */,
 				4A63BE5429A601F900A30CA8 /* InstructionViewController.swift in Sources */,
+				9A82AF3229B9FD130056315D /* PracticeSongCardView.swift in Sources */,
 				A951F6532989EF6C00902CED /* String+Extension.swift in Sources */,
 				7BC275602987EA10008F4B9F /* emptyView.swift in Sources */,
 				A96F3686299E2EA200376620 /* BandMemberAddTableViewCell.swift in Sources */,

--- a/GetARock/GetARock.xcodeproj/project.pbxproj
+++ b/GetARock/GetARock.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		9A78BFE5298A9D7500953E4B /* DuplicationCheckRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */; };
 		9A82AF2F29B9FCBA0056315D /* PracticeSongBoxView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A82AF2E29B9FCBA0056315D /* PracticeSongBoxView.swift */; };
 		9A82AF3229B9FD130056315D /* PracticeSongCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A82AF3129B9FD130056315D /* PracticeSongCardView.swift */; };
+		9A82AF3429B9FDBA0056315D /* AddPracticeSongViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A82AF3329B9FDBA0056315D /* AddPracticeSongViewController.swift */; };
 		9AA0BB4F29A4E7FD00871A05 /* NotificationListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0BB4E29A4E7FD00871A05 /* NotificationListViewController.swift */; };
 		9AA0BB5129A4E81700871A05 /* NotificationListVO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0BB5029A4E81700871A05 /* NotificationListVO.swift */; };
 		9AA0BB5329A4E83400871A05 /* NotificationTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA0BB5229A4E83400871A05 /* NotificationTableViewCell.swift */; };
@@ -222,6 +223,7 @@
 		9A78BFE4298A9D7500953E4B /* DuplicationCheckRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DuplicationCheckRequest.swift; sourceTree = "<group>"; };
 		9A82AF2E29B9FCBA0056315D /* PracticeSongBoxView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeSongBoxView.swift; sourceTree = "<group>"; };
 		9A82AF3129B9FD130056315D /* PracticeSongCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeSongCardView.swift; sourceTree = "<group>"; };
+		9A82AF3329B9FDBA0056315D /* AddPracticeSongViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPracticeSongViewController.swift; sourceTree = "<group>"; };
 		9AA0BB4E29A4E7FD00871A05 /* NotificationListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationListViewController.swift; sourceTree = "<group>"; };
 		9AA0BB5029A4E81700871A05 /* NotificationListVO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationListVO.swift; sourceTree = "<group>"; };
 		9AA0BB5229A4E83400871A05 /* NotificationTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationTableViewCell.swift; sourceTree = "<group>"; };
@@ -423,6 +425,7 @@
 			children = (
 				9A82AF2E29B9FCBA0056315D /* PracticeSongBoxView.swift */,
 				9A82AF3129B9FD130056315D /* PracticeSongCardView.swift */,
+				9A82AF3329B9FDBA0056315D /* AddPracticeSongViewController.swift */,
 			);
 			path = PracticeSongAddFlow;
 			sourceTree = "<group>";
@@ -999,6 +1002,7 @@
 				9ABDA8CE29B0C03200DE710D /* PositionSelectForInvitationViewController.swift in Sources */,
 				B88E1B9F2977A70E006072B7 /* AppDelegate.swift in Sources */,
 				9ACA5858299B6CEE00C6C2BC /* SNSBoxView.swift in Sources */,
+				9A82AF3429B9FDBA0056315D /* AddPracticeSongViewController.swift in Sources */,
 				7B236A8529854196006AE385 /* IconImageView.swift in Sources */,
 				7B56DC3E29A36F2F00672EDD /* UIView+Extension.swift in Sources */,
 				7BB4FA84299B708C00C44184 /* EventStateLabel.swift in Sources */,

--- a/GetARock/GetARock/Global/Extension/Notification.Name+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/Notification.Name+Extension.swift
@@ -14,4 +14,5 @@ extension Notification.Name {
     static let hideDeselectAllPositionButton = Notification.Name("hideDeselectAllPositionButton")
     static let didTapPositionItem = Notification.Name("didTapPositionItem")
     static let loadBandData = NSNotification.Name("LoadBandData")
+    static let didPracticeCardViewTextFieldChange = NSNotification.Name("didPracticeCardViewTextFieldChange")
 }

--- a/GetARock/GetARock/Global/Extension/UITextField+Extension.swift
+++ b/GetARock/GetARock/Global/Extension/UITextField+Extension.swift
@@ -22,7 +22,7 @@ extension UITextField {
             $0.backgroundColor = .dark02
             $0.textColor = .white
             
-            $0.leftView = TextFieldLeftPaddingView()
+            $0.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 20, height: 20))
             $0.leftViewMode = .always
 
             return $0
@@ -45,25 +45,9 @@ extension UITextField {
     }
 }
 
-final class TextFieldLeftPaddingView: UIView {
-    override init(frame: CGRect) {
-        super.init(frame: .zero)
-        
-        self.constraint(.widthAnchor, constant: 20)
-        self.constraint(.heightAnchor, constant: 20)
-    }
-    
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-}
-
 final class TextFieldRightPaddingView: UIView {
     override init(frame: CGRect) {
-        super.init(frame: .zero)
-
-        self.constraint(.widthAnchor, constant: 100)
-        self.constraint(.heightAnchor, constant: 20)
+        super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 20))
     }
 
     required init?(coder: NSCoder) {

--- a/GetARock/GetARock/Global/Literal/ImageLiteral.swift
+++ b/GetARock/GetARock/Global/Literal/ImageLiteral.swift
@@ -33,6 +33,7 @@ enum ImageLiteral {
     static var scopeSymbol: UIImage { .load(systemName: "scope") }
 
     static var exclamationMarkCircleSymbol: UIImage { .load(systemName: "exclamationmark.circle") }
+    static var quarternoteSymbol: UIImage { .load(systemName: "music.quarternote.3") }
 
     
     // MARK: - icon

--- a/GetARock/GetARock/Global/UIComponent/BasicTextField.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextField.swift
@@ -38,11 +38,6 @@ final class BasicTextField: UIView {
         self.addSubview(textField)
         textField.constraint(to: self)
     }
-    
-    func isTextFieldEmpty() -> Bool {
-        guard let isTextFieldEmpty = self.textField.text?.isEmpty else { return true }
-        return isTextFieldEmpty
-    }
 }
 
 extension BasicTextField {

--- a/GetARock/GetARock/Global/UIComponent/BasicTextField.swift
+++ b/GetARock/GetARock/Global/UIComponent/BasicTextField.swift
@@ -6,16 +6,29 @@
 //
 import UIKit
 
+protocol BasicTextFieldDelegate: AnyObject {
+    func textFieldTextDidChange()
+}
+
 final class BasicTextField: UIView {
 
+    weak var delegate: BasicTextFieldDelegate?
+    
     private let placeholder: String
 
-    lazy var textField: UITextField = UITextField.makeBasicTextField(placeholder: placeholder)
+    lazy var textField: UITextField = {
+        $0.addTarget(self, action: #selector(textFieldTextDidChange), for: .editingChanged)
+        return $0
+    }(UITextField.makeBasicTextField(placeholder: placeholder))
 
     init(placeholder: String) {
         self.placeholder = placeholder
         super.init(frame: .zero)
         self.setupLayout()
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     private func setupLayout() {
@@ -25,8 +38,15 @@ final class BasicTextField: UIView {
         self.addSubview(textField)
         textField.constraint(to: self)
     }
+    
+    func isTextFieldEmpty() -> Bool {
+        guard let isTextFieldEmpty = self.textField.text?.isEmpty else { return true }
+        return isTextFieldEmpty
+    }
+}
 
-    required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+extension BasicTextField {
+    @objc func textFieldTextDidChange() {
+        delegate?.textFieldTextDidChange()
     }
 }

--- a/GetARock/GetARock/Global/UIComponent/DefaultButton.swift
+++ b/GetARock/GetARock/Global/UIComponent/DefaultButton.swift
@@ -24,7 +24,6 @@ final class DefaultButton: UIButton {
         layer.borderWidth = 1
         layer.masksToBounds = true
         layer.cornerRadius = 10
-        
         titleLabel?.font = UIFont.setFont(.contentBold)
         setTitleColor(.white, for: .normal)
     }

--- a/GetARock/GetARock/Screens/BandCreation/BandInformationSetFlow/BandInformationSetViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/BandInformationSetFlow/BandInformationSetViewController.swift
@@ -80,7 +80,7 @@ final class BandInformationSetViewController: BaseViewController {
 
     private let detailpracticeRoomTextField: BasicTextField = {
         let rightPaddingView = TextFieldRightPaddingView()
-        rightPaddingView.constraint(.widthAnchor, constant: 20)
+        rightPaddingView.frame = CGRect(x: 0, y: 0, width: 20, height: 20)
         $0.textField.rightView = rightPaddingView
         $0.textField.rightViewMode = .always
         return $0

--- a/GetARock/GetARock/Screens/BandCreation/BandInformationSetFlow/BandInformationSetViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/BandInformationSetFlow/BandInformationSetViewController.swift
@@ -279,6 +279,15 @@ extension BandInformationSetViewController {
 
     //MARK: 합주곡 추가 기능 관련 로직
     @objc func didTapAddPracticeSong() {
+        let nextViewController = AddPracticeSongViewController()
+        nextViewController.completion = { [weak self] songs in
+            let addedSongs: [PracticeSongBoxView] = self?.makePracticeSongBoxes(with: songs) ?? []
+            for song in addedSongs {
+                if self?.practiceSongList.arrangedSubviews.count ?? 0 > 3 { break }
+                self?.practiceSongList.addArrangedSubview(song)
+            }
+        }
+        navigationController?.pushViewController(nextViewController, animated: true)
     }
 
     @objc func didTouchScreen() {
@@ -292,6 +301,19 @@ extension BandInformationSetViewController {
     //TODO: 밴드 정보를 서버에 POST 하는 코드 추가 예정
     private func postBandInformation() {
 
+    }
+}
+
+    //추가된 합주곡 정보를 바탕으로 Box형 UI를 만드는 함수
+extension BandInformationSetViewController {
+    func makePracticeSongBoxes(with data: [PracticeSongCardView]) -> [PracticeSongBoxView] {
+        var result: [PracticeSongBoxView] = []
+        for datum in data {
+            let practiceSong: PracticeSongBoxView = PracticeSongBoxView()
+            practiceSong.configure(data: datum)
+            result.append(practiceSong)
+        }
+        return result
     }
 }
 

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
@@ -144,11 +144,12 @@ final class AddPracticeSongViewController: BaseViewController {
     }
     
     private func updateDeleteButtonState() {
-        if contentView.arrangedSubviews.count == 1 {
-            contentView.arrangedSubviews.compactMap { $0 as? PracticeSongCardView }.forEach { $0.deleteButton.isHidden = true }
-        } else {
-            contentView.arrangedSubviews.compactMap { $0 as? PracticeSongCardView }.forEach { $0.deleteButton.isHidden = false }
-        }
+        let practiceSongs = contentView.arrangedSubviews.compactMap { $0 as? PracticeSongCardView }
+                if contentView.arrangedSubviews.count == 1 {
+                    practiceSongs.forEach { $0.hideDeleteButton()}
+                } else {
+                    practiceSongs.forEach { $0.showDeleteButton() }
+                }
     }
     
     private func setKeyboardDismiss() {
@@ -161,13 +162,15 @@ final class AddPracticeSongViewController: BaseViewController {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(getKeyboardHeight(notification: )),
-            name: UIResponder.keyboardWillShowNotification, object: nil
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
         )
         
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(updateCompleteButtonState),
-            name: Notification.Name.didPracticeCardViewTextFieldChange, object: nil
+            name: Notification.Name.didPracticeCardViewTextFieldChange,
+            object: nil
         )
     }
     
@@ -179,6 +182,7 @@ final class AddPracticeSongViewController: BaseViewController {
             self?.numberOfSong = self?.contentView.arrangedSubviews.count ?? 0
             UIView.animate(withDuration: 0.2) {
                 self?.contentView.layoutIfNeeded() // StackView 레이아웃 재조정 애니메이션
+                self?.updateCompleteButtonState()
             }
         })
     }
@@ -202,6 +206,7 @@ extension AddPracticeSongViewController {
                 self?.numberOfSong = self?.contentView.arrangedSubviews.count ?? 0
                 UIView.animate(withDuration: 0.3) { // StackView 레이아웃 재조정 애니메이션
                     self?.contentView.layoutIfNeeded()
+                    self?.updateCompleteButtonState()
                 }
             })
         }
@@ -229,7 +234,7 @@ extension AddPracticeSongViewController {
     private func updateCompleteButtonState() {
         let isAllRequiredInfoFilled = contentView.arrangedSubviews
             .compactMap { $0 as? PracticeSongCardView }
-            .filter { $0.getSongName().isEmpty || $0.getArtistName().isEmpty } // 정보가 하나라도 누락된 card만 필터링함
+            .filter { $0.songName().isEmpty || $0.artistName().isEmpty } // 정보가 하나라도 누락된 card만 필터링함
             .isEmpty // 정보가 누락되었는지 여부를 원소로 가지는 배열이 비어있다면, 모든 정보가 채워진 것임
         
         if isAllRequiredInfoFilled {

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
@@ -20,11 +20,7 @@ final class AddPracticeSongViewController: BaseViewController {
         didSet {
             addPracticeSongButton.configuration?.title = "합주곡 추가\(numberOfSong)/3"
             addPracticeSongButton.configuration?.attributedTitle?.font = UIFont.setFont(.contentBold)
-            if numberOfSong == 3 {
-                addPracticeSongButton.isHidden = true
-            } else {
-                addPracticeSongButton.isHidden = false
-            }
+                addPracticeSongButton.isHidden = numberOfSong == 3 ? true : false
         }
     }
     

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
@@ -26,21 +26,22 @@ final class AddPracticeSongViewController: BaseViewController {
     
     // MARK: - View
     
-    private let firstPracticeSongCard: PracticeSongCardView = PracticeSongCardView()
+    private lazy var firstPracticeSongCard: PracticeSongCardView = {
+        let deleteAction: UIAction = UIAction { [weak self] _ in
+            self?.deleteFirstPracticeSongCard()
+        }
+        $0.deleteButton.addAction(deleteAction, for: .touchUpInside)
+        return $0
+    }(PracticeSongCardView())
     
     private lazy var contentView: UIStackView = {
         $0.axis = .vertical
         $0.distribution = .equalSpacing
         $0.spacing = 40
-        let deleteAction: UIAction = UIAction { [weak self] _ in
-            self?.deleteFirstPracticeSongCard()
-        }
-        firstPracticeSongCard.deleteButton.addAction(deleteAction, for: .touchUpInside)
         return $0
     }(UIStackView(arrangedSubviews: [firstPracticeSongCard]))
     
     private lazy var mainScrollView: UIScrollView = {
-        $0.showsVerticalScrollIndicator = true
         $0.backgroundColor = .dark01
         return $0
     }(UIScrollView())
@@ -109,23 +110,37 @@ final class AddPracticeSongViewController: BaseViewController {
         
         // contentView는 stackView라서 높이정보가 자동으로 세팅됨
         // 따라서 스크롤범위를 맞추기위해 contentView의 하단 constraint가 필요함
-        contentView.constraint(top: mainScrollView.contentLayoutGuide.topAnchor,
-                               bottom: mainScrollView.contentLayoutGuide.bottomAnchor, centerX: mainScrollView.centerXAnchor,
-                               padding: UIEdgeInsets(top: 20, left: 0, bottom: 160, right: 0))
+        contentView.constraint(
+            top: mainScrollView.topAnchor,
+            leading: mainScrollView.leadingAnchor,
+            bottom: mainScrollView.bottomAnchor,
+            trailing: mainScrollView.trailingAnchor,
+            padding: UIEdgeInsets(top: 20,
+                                  left: 16,
+                                  bottom: 160,
+                                  right: 16))
         
         mainScrollView.addSubview(addPracticeSongButton)
         
-        addPracticeSongButton.constraint(top: contentView.bottomAnchor,
-                                         leading: contentView.leadingAnchor,
-                                         trailing: contentView.trailingAnchor,
-                                         padding: UIEdgeInsets(top: 20, left: 20, bottom: 0, right: 20))
+        addPracticeSongButton.constraint(
+            top: contentView.bottomAnchor,
+            leading: contentView.leadingAnchor,
+            trailing: contentView.trailingAnchor,
+            padding: UIEdgeInsets(top: 20,
+                                  left: 20,
+                                  bottom: 0,
+                                  right: 20))
         
         mainScrollView.addSubview(addCompleteButton)
         
-        addCompleteButton.constraint(top: addPracticeSongButton.bottomAnchor,
-                                     leading: view.safeAreaLayoutGuide.leadingAnchor,
-                                     trailing: view.safeAreaLayoutGuide.trailingAnchor,
-                                     padding: UIEdgeInsets(top: 40, left: 20, bottom: 10, right: 20))
+        addCompleteButton.constraint(
+            top: addPracticeSongButton.bottomAnchor,
+            leading: view.safeAreaLayoutGuide.leadingAnchor,
+            trailing: view.safeAreaLayoutGuide.trailingAnchor,
+            padding: UIEdgeInsets(top: 40,
+                                  left: 20,
+                                  bottom: 10,
+                                  right: 20))
     }
     
     private func updateDeleteButtonState() {

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
@@ -18,9 +18,9 @@ final class AddPracticeSongViewController: BaseViewController {
             addPracticeSongButton.configuration?.title = "합주곡 추가\(numberOfSong)/3"
             addPracticeSongButton.configuration?.attributedTitle?.font = UIFont.setFont(.contentBold)
             if numberOfSong == 3 {
-                addPracticeSongButton.isEnabled = false
+                addPracticeSongButton.isHidden = true
             } else {
-                addPracticeSongButton.isEnabled = true
+                addPracticeSongButton.isHidden = false
             }
         }
     }
@@ -44,38 +44,36 @@ final class AddPracticeSongViewController: BaseViewController {
         return $0
     }(UIScrollView())
     
-    private lazy var addPracticeSongButton: DefaultButton = {
+    private lazy var addPracticeSongButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
         configuration.image = ImageLiteral.plusSymbol
         configuration.title = "합주곡 추가 \(numberOfSong)/3"
         configuration.attributedTitle?.font = UIFont.setFont(.contentBold)
         configuration.imagePadding = 10
-        
-        let button = DefaultButton(configuration: configuration)
-        button.setBackgroundColor(.dark04, for: .disabled)
+        let button = UIButton(configuration: configuration)
         button.tintColor = .white
-        button.constraint(.heightAnchor, constant: 55)
+        button.backgroundColor = .dark02
+        button.layer.cornerRadius = 10
+        button.layer.borderWidth = 1
+        button.layer.borderColor = UIColor.gray02.cgColor
+        button.constraint(.heightAnchor, constant: 50)
         button.addTarget(self, action: #selector(didTapAddPracticeSong), for: .touchUpInside)
         return button
     }()
     
-    private lazy var completeButton: DefaultButton = {
-        var configuration = UIButton.Configuration.plain()
-        configuration.title = "추가"
-        configuration.attributedTitle?.font = UIFont.setFont(.contentBold)
-        let button = DefaultButton(configuration: configuration)
-        button.tintColor = .white
-        button.constraint(.heightAnchor, constant: 55)
-        button.addTarget(self, action: #selector(didTapCompleteButton), for: .touchUpInside)
-        return button
-    }()
+    private lazy var addCompleteButton: BottomButton = {
+        $0.setTitle("추가", for: .normal)
+        $0.isEnabled = false
+        $0.addTarget(self, action: #selector(didTapCompleteButton), for: .touchUpInside)
+        return $0
+    }(BottomButton())
     
     override func viewDidLoad() {
         super.viewDidLoad()
         setupLayout()
         attribute()
         setKeyboardDismiss()
-        setNotification()
+        setNotificationObserver()
     }
     
     override func viewDidLayoutSubviews() {
@@ -110,9 +108,9 @@ final class AddPracticeSongViewController: BaseViewController {
                                          trailing: contentView.trailingAnchor,
                                          padding: UIEdgeInsets(top: 20, left: 20, bottom: 0, right: 20))
         
-        mainScrollView.addSubview(completeButton)
+        mainScrollView.addSubview(addCompleteButton)
         
-        completeButton.constraint(top: addPracticeSongButton.bottomAnchor,
+        addCompleteButton.constraint(top: addPracticeSongButton.bottomAnchor,
                                   leading: view.safeAreaLayoutGuide.leadingAnchor,
                                   trailing: view.safeAreaLayoutGuide.trailingAnchor,
                                   padding: UIEdgeInsets(top: 40, left: 20, bottom: 10, right: 20))
@@ -132,7 +130,7 @@ final class AddPracticeSongViewController: BaseViewController {
         mainScrollView.addGestureRecognizer(recognizer)
     }
     
-    private func setNotification() {
+    private func setNotificationObserver() {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(getKeyboardHeight(notification: )),
@@ -160,7 +158,7 @@ extension AddPracticeSongViewController {
         guard contentView.arrangedSubviews.count < 3 else { return }
         let newCard = PracticeSongCardView()
         newCard.setTextFieldDelegate(controller: self)
-        let deleteAction: UIAction = UIAction { [weak self]_ in
+        let deleteAction: UIAction = UIAction { [weak self] _ in
             UIView.animate(withDuration: 0.4, animations: {
                 newCard.alpha = 0 // fade out 애니메이션
             }, completion: { [weak self] _ in

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
@@ -1,0 +1,207 @@
+//
+//  AddPracticeSongViewController.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/03/09.
+//
+
+import UIKit
+
+final class AddPracticeSongViewController: BaseViewController {
+    
+    private var keyBoardHeight: CGFloat = 280
+    
+    var completion: (_ songs: [PracticeSongCardView]) -> Void = { songs in }
+    
+    private var numberOfSong: Int = 1 {
+        didSet {
+            addPracticeSongButton.configuration?.title = "합주곡 추가\(numberOfSong)/3"
+            addPracticeSongButton.configuration?.attributedTitle?.font = UIFont.setFont(.contentBold)
+            if numberOfSong == 3 {
+                addPracticeSongButton.isEnabled = false
+            } else {
+                addPracticeSongButton.isEnabled = true
+            }
+        }
+    }
+    
+    private let firstPracticeSongCard: PracticeSongCardView = PracticeSongCardView()
+    
+    private lazy var contentView: UIStackView = {
+        $0.axis = .vertical
+        $0.distribution = .equalSpacing
+        $0.spacing = 40
+        let deleteAction: UIAction = UIAction { [weak self] _ in
+            self?.deletefirstPracticeSongCard()
+        }
+        firstPracticeSongCard.deleteButton.addAction(deleteAction, for: .touchUpInside)
+        return $0
+    }(UIStackView(arrangedSubviews: [firstPracticeSongCard]))
+    
+    private lazy var mainScrollView: UIScrollView = {
+        $0.showsVerticalScrollIndicator = true
+        $0.backgroundColor = .dark01
+        return $0
+    }(UIScrollView())
+    
+    private lazy var addPracticeSongButton: DefaultButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = ImageLiteral.plusSymbol
+        configuration.title = "합주곡 추가 \(numberOfSong)/3"
+        configuration.attributedTitle?.font = UIFont.setFont(.contentBold)
+        configuration.imagePadding = 10
+        
+        let button = DefaultButton(configuration: configuration)
+        button.setBackgroundColor(.dark04, for: .disabled)
+        button.tintColor = .white
+        button.constraint(.heightAnchor, constant: 55)
+        button.addTarget(self, action: #selector(didTapAddPracticeSong), for: .touchUpInside)
+        return button
+    }()
+    
+    private lazy var completeButton: DefaultButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.title = "추가"
+        configuration.attributedTitle?.font = UIFont.setFont(.contentBold)
+        let button = DefaultButton(configuration: configuration)
+        button.tintColor = .white
+        button.constraint(.heightAnchor, constant: 55)
+        button.addTarget(self, action: #selector(didTapCompleteButton), for: .touchUpInside)
+        return button
+    }()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupLayout()
+        attribute()
+        setKeyboardDismiss()
+        setNotification()
+    }
+    
+    override func viewDidLayoutSubviews() {
+        updateDeleteButtonState()
+    }
+    
+    private func attribute() {
+        self.view.backgroundColor = .dark01
+    }
+    
+    private func setupLayout() {
+        
+        view.addSubview(mainScrollView)
+        
+        mainScrollView.constraint(top: view.topAnchor,
+                                  leading: view.leadingAnchor,
+                                  bottom: view.bottomAnchor,
+                                  trailing: view.trailingAnchor)
+        
+        mainScrollView.addSubview(contentView)
+
+        // contentView는 stackView라서 높이정보가 자동으로 세팅됨
+        // 따라서 스크롤범위를 맞추기위해 contentView의 하단 constraint가 필요함
+        contentView.constraint(top: mainScrollView.contentLayoutGuide.topAnchor,
+                               bottom: mainScrollView.contentLayoutGuide.bottomAnchor, centerX: mainScrollView.centerXAnchor,
+                               padding: UIEdgeInsets(top: 20, left: 0, bottom: 160, right: 0))
+        
+        mainScrollView.addSubview(addPracticeSongButton)
+        
+        addPracticeSongButton.constraint(top: contentView.bottomAnchor,
+                                         leading: contentView.leadingAnchor,
+                                         trailing: contentView.trailingAnchor,
+                                         padding: UIEdgeInsets(top: 20, left: 20, bottom: 0, right: 20))
+        
+        mainScrollView.addSubview(completeButton)
+        
+        completeButton.constraint(top: addPracticeSongButton.bottomAnchor,
+                                  leading: view.safeAreaLayoutGuide.leadingAnchor,
+                                  trailing: view.safeAreaLayoutGuide.trailingAnchor,
+                                  padding: UIEdgeInsets(top: 40, left: 20, bottom: 10, right: 20))
+    }
+    
+    private func updateDeleteButtonState() {
+        //TODO: 강제언래핑 없애기
+        if contentView.arrangedSubviews.count == 1 {
+            contentView.arrangedSubviews.map { $0 as! PracticeSongCardView }.forEach { $0.deleteButton.isHidden = true }
+        } else {
+            contentView.arrangedSubviews.map { $0 as! PracticeSongCardView }.forEach { $0.deleteButton.isHidden = false }
+        }
+    }
+    
+    private func setKeyboardDismiss() {
+        let recognizer = UITapGestureRecognizer(target: self, action: #selector(self.didTouchScreen))
+        mainScrollView.addGestureRecognizer(recognizer)
+    }
+    
+    private func setNotification() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(getKeyboardHeight(notification: )),
+            name: UIResponder.keyboardWillShowNotification, object: nil
+        )
+    }
+}
+
+extension AddPracticeSongViewController {
+    
+    private func deletefirstPracticeSongCard() {
+        UIView.animate(withDuration: 0.4, animations: {
+            self.firstPracticeSongCard.alpha = 0 // fade out 애니메이션
+        }, completion: { [weak self] _ in
+            self?.firstPracticeSongCard.removeFromSuperview()
+            self?.numberOfSong = self?.contentView.arrangedSubviews.count ?? 0
+            UIView.animate(withDuration: 0.2) {
+                self?.contentView.layoutIfNeeded() // StackView 레이아웃 재조정 애니메이션
+            }
+        })
+    }
+    
+    @objc
+    func didTapAddPracticeSong() {
+        guard contentView.arrangedSubviews.count < 3 else { return }
+        let newCard = PracticeSongCardView()
+        newCard.setTextFieldDelegate(controller: self)
+        let deleteAction: UIAction = UIAction { [weak self]_ in
+            UIView.animate(withDuration: 0.4, animations: {
+                newCard.alpha = 0 // fade out 애니메이션
+            }, completion: { [weak self] _ in
+                newCard.removeFromSuperview()
+                self?.numberOfSong = self?.contentView.arrangedSubviews.count ?? 0
+                UIView.animate(withDuration: 0.3) { // StackView 레이아웃 재조정 애니메이션
+                    self?.contentView.layoutIfNeeded()
+                }
+            })
+        }
+        newCard.deleteButton.addAction(deleteAction, for: .touchUpInside)
+        contentView.insertArrangedSubview(newCard, at: contentView.arrangedSubviews.endIndex)
+        numberOfSong = contentView.arrangedSubviews.count
+        updateDeleteButtonState()
+    }
+    
+    @objc
+    func didTapCompleteButton() {
+        let addedSongs: [PracticeSongCardView] = contentView.arrangedSubviews.map { $0 as! PracticeSongCardView }
+        completion(addedSongs)
+        self.navigationController?.popViewController(animated: true)
+    }
+    
+    @objc
+    func didTouchScreen() {
+        self.view.endEditing(true)
+    }
+    
+    @objc
+    func getKeyboardHeight(notification: Notification) {
+        keyBoardHeight = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue.height ?? 0
+    }
+}
+
+extension AddPracticeSongViewController: UITextFieldDelegate {
+    func textFieldDidBeginEditing(_ textField: UITextField) {
+        self.view.frame.origin.y -= self.keyBoardHeight
+    }
+    
+    func textFieldDidEndEditing(_ textField: UITextField) {
+        self.view.frame.origin.y += self.keyBoardHeight
+    }
+}
+

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift
@@ -81,6 +81,7 @@ final class AddPracticeSongViewController: BaseViewController {
         attribute()
         setKeyboardDismiss()
         setNotificationObserver()
+        setNavigationInlineTitle(title: "합주곡 추가")
     }
     
     override func viewDidLayoutSubviews() {

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongBoxView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongBoxView.swift
@@ -1,0 +1,104 @@
+//
+//  PracticeSongBoxView.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/03/09.
+//
+
+import UIKit
+
+final class PracticeSongBoxView: UIView {
+    
+    // MARK: - View
+    
+    private let songTitleLabel: BasicLabel = {
+        $0.numberOfLines = 2
+        return $0
+    }(BasicLabel(contentText: "", fontStyle: .content, textColorInfo: .white))
+    
+    private let artistLabel: BasicLabel = {
+        $0.numberOfLines = 2
+        return $0
+    }(BasicLabel(contentText: "", fontStyle: .content, textColorInfo: .gray02))
+    
+    private lazy var musicIconImage: UIImageView = {
+        $0.image = ImageLiteral.quarternoteSymbol
+        $0.constraint(.widthAnchor, constant: 24)
+        $0.constraint(.heightAnchor, constant: 24)
+        $0.contentMode = .scaleAspectFit
+        $0.tintColor = .white
+        $0.setContentHuggingPriority(UILayoutPriority(rawValue: 500),
+                                     for: .horizontal)
+        $0.setContentCompressionResistancePriority(UILayoutPriority(rawValue: 760),
+                                                   for: .horizontal)
+        return $0
+    }(UIImageView())
+    
+    private lazy var deleteButton: UIButton = {
+        let imageConfiguation = UIImage.SymbolConfiguration(pointSize: 20)
+        $0.setImage(UIImage(
+            systemName: "xmark.circle.fill",
+            withConfiguration: imageConfiguation),for: .normal
+        )
+        $0.contentMode = .scaleAspectFit
+        $0.tintColor = .gray02
+        let action = UIAction { [weak self] _ in
+            UIView.animate(withDuration: 0.3, animations: {
+                self?.alpha = 0
+            }, completion: { [weak self] _ in
+                self?.removeFromSuperview()
+            })
+        }
+        $0.addAction(action, for: .touchUpInside)
+        return $0
+    }(UIButton())
+    
+    private lazy var songLabelStackView: UIStackView = {
+        $0.axis = .vertical
+        $0.spacing = 3
+        return $0
+    }(UIStackView(arrangedSubviews: [songTitleLabel,artistLabel]))
+    
+    private lazy var songStackView: UIStackView = {
+        $0.backgroundColor = .dark02
+        $0.axis = .horizontal
+        $0.distribution = .fill
+        $0.spacing = 15
+        $0.layer.cornerRadius = 10
+        $0.isLayoutMarginsRelativeArrangement = true
+        $0.layoutMargins = UIEdgeInsets(top: 15.0, left: 20.0, bottom: 15.0, right: 20.0)
+        $0.layer.borderColor = UIColor.gray02.cgColor
+        $0.layer.borderWidth = 1
+        return $0
+    }(UIStackView(arrangedSubviews: [musicIconImage,
+                                     songLabelStackView]))
+    
+    // MARK: - Init
+    
+    override init(frame: CGRect) {
+        super.init(frame: .zero)
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    // MARK: - Method
+    
+    private func setupLayout() {
+        self.addSubview(songStackView)
+        songStackView.constraint(to: self)
+        songStackView.constraint(.heightAnchor, constant: 70)
+        self.addSubview(deleteButton)
+        deleteButton.constraint(trailing: self.trailingAnchor,
+                                centerY: self.centerYAnchor,
+                                padding: UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 20))
+    }
+    
+    func configure(data: PracticeSongCardView) {
+        songTitleLabel.text = data.getSongName()
+        artistLabel.text = data.getArtistName()
+    }
+}
+

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongBoxView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongBoxView.swift
@@ -97,8 +97,8 @@ final class PracticeSongBoxView: UIView {
     }
     
     func configure(data: PracticeSongCardView) {
-        songTitleLabel.text = data.getSongName()
-        artistLabel.text = data.getArtistName()
+        songTitleLabel.text = data.songName()
+        artistLabel.text = data.artistName()
     }
 }
 

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongCardView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongCardView.swift
@@ -17,7 +17,7 @@ final class PracticeSongCardView: UIStackView {
         return $0
     }(UIButton())
     
-    private let practiceSongName: InformationGuideLabel = InformationGuideLabel(guideText: "합주곡 제목", type: .required)
+    private let practiceSongNameGuideLabel: InformationGuideLabel = InformationGuideLabel(guideText: "합주곡 제목", type: .required)
     
     private lazy var practiceSongTextField: BasicTextField = {
         $0.delegate = self
@@ -30,9 +30,9 @@ final class PracticeSongCardView: UIStackView {
         $0.axis = .vertical
         $0.spacing = 10
         return $0
-    }(UIStackView(arrangedSubviews: [practiceSongName, practiceSongTextField]))
+    }(UIStackView(arrangedSubviews: [practiceSongNameGuideLabel, practiceSongTextField]))
     
-    private let artistName: InformationGuideLabel = InformationGuideLabel(guideText: "아티스트", type: .required)
+    private let artistNameGuideLabel: InformationGuideLabel = InformationGuideLabel(guideText: "아티스트", type: .required)
     
     private lazy var artistNameTextField: BasicTextField = {
         $0.delegate = self
@@ -45,7 +45,7 @@ final class PracticeSongCardView: UIStackView {
         $0.axis = .vertical
         $0.spacing = 10
         return $0
-    }(UIStackView(arrangedSubviews: [artistName, artistNameTextField]))
+    }(UIStackView(arrangedSubviews: [artistNameGuideLabel, artistNameTextField]))
     
     private let linkLabel: InformationGuideLabel = InformationGuideLabel(guideText: "링크", type: .optional)
     
@@ -103,12 +103,20 @@ final class PracticeSongCardView: UIStackView {
         deleteButton.isHidden = true
     }
     
-    func getArtistName() -> String {
+    func artistName() -> String {
         return artistNameTextField.textField.text ?? ""
     }
     
-    func getSongName() -> String {
+    func songName() -> String {
         return practiceSongTextField.textField.text ?? ""
+    }
+
+    func hideDeleteButton() {
+        deleteButton.isHidden = true
+    }
+
+    func showDeleteButton() {
+        deleteButton.isHidden = false
     }
     
     func setTextFieldDelegate(controller: UITextFieldDelegate) {

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongCardView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongCardView.swift
@@ -1,0 +1,112 @@
+//
+//  PracticeSongCardView.swift
+//  GetARock
+//
+//  Created by 장지수 on 2023/03/09.
+//
+
+import UIKit
+
+final class PracticeSongCardView: UIStackView {
+
+    lazy var deleteButton: UIButton = {
+        $0.setImage(ImageLiteral.xmarkSymbol, for: .normal)
+        $0.tintColor = .white
+        return $0
+    }(UIButton())
+    
+    private let practiceSongName: InformationGuideLabel = InformationGuideLabel(guideText: "합주곡 제목", type: .required)
+    
+    private let practiceSongTextField: BasicTextField = {
+        $0.constraint(.widthAnchor,
+                      constant: BasicComponentSize.width - 40)
+        return $0
+    }(BasicTextField(placeholder: "합주곡 제목을 입력해주세요"))
+    
+    private lazy var practiceSongNameVstack: UIStackView = {
+        $0.axis = .vertical
+        $0.spacing = 10
+        return $0
+    }(UIStackView(arrangedSubviews: [practiceSongName, practiceSongTextField]))
+    
+    private let artistName: InformationGuideLabel = InformationGuideLabel(guideText: "아티스트", type: .required)
+    
+    private let artistNameTextField: BasicTextField = {
+        $0.constraint(.widthAnchor,
+                      constant: BasicComponentSize.width - 20)
+        return $0
+    }(BasicTextField(placeholder: "아티스트를 입력해주세요"))
+    
+    private lazy var artistNameVstack: UIStackView = {
+        $0.axis = .vertical
+        $0.spacing = 10
+        return $0
+    }(UIStackView(arrangedSubviews: [artistName, artistNameTextField]))
+    
+    private let linkLabel: InformationGuideLabel = InformationGuideLabel(guideText: "링크", type: .optional)
+    
+    private let linkDescription: BasicLabel = BasicLabel(
+        contentText: "* 해당 곡을 합주한 작업물 링크를 입력해주세요",
+        fontStyle: .content,
+        textColorInfo: .gray02)
+    
+    private let linkTextField: BasicTextField = {
+        $0.constraint(.widthAnchor,
+                      constant: BasicComponentSize.width - 20)
+        return $0
+    }(BasicTextField(placeholder: "합주 영상이나 녹음파일 링크를 입력해주세요"))
+    
+    private lazy var linkVstack: UIStackView = {
+        $0.axis = .vertical
+        $0.spacing = 10
+        return $0
+    }(UIStackView(arrangedSubviews: [linkLabel, linkDescription, linkTextField]))
+    
+    init() {
+        super.init(frame: .zero)
+        setupLayout()
+        attribute()
+    }
+    
+    private func setupLayout() {
+        self.addArrangedSubview(practiceSongNameVstack)
+        self.addArrangedSubview(artistNameVstack)
+        self.addArrangedSubview(linkVstack)
+
+        self.addSubview(deleteButton)
+        deleteButton.constraint(top: self.topAnchor,
+                                trailing: self.trailingAnchor,
+                                padding: UIEdgeInsets(top: 10, left: 0, bottom: 0, right: 10))
+    }
+    
+    private func attribute() {
+        self.layer.borderWidth = 1
+        self.layer.cornerRadius = 10
+        self.layer.borderColor = UIColor.white.cgColor
+        self.backgroundColor = .dark02
+        self.axis = .vertical
+        self.spacing = 40
+        self.isLayoutMarginsRelativeArrangement = true
+        self.layoutMargins = UIEdgeInsets(top: 30, left: 20, bottom: 30, right: 20)
+        deleteButton.isHidden = true
+    }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func getArtistName() -> String {
+        return artistNameTextField.textField.text ?? ""
+    }
+    
+    func getSongName() -> String {
+        return practiceSongTextField.textField.text ?? ""
+    }
+    
+    func setTextFieldDelegate(controller: UITextFieldDelegate) {
+        artistNameTextField.textField.delegate = controller
+        practiceSongTextField.textField.delegate = controller
+        linkTextField.textField.delegate = controller
+    }
+}
+

--- a/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongCardView.swift
+++ b/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongCardView.swift
@@ -8,6 +8,8 @@
 import UIKit
 
 final class PracticeSongCardView: UIStackView {
+    
+    // MARK: - View
 
     lazy var deleteButton: UIButton = {
         $0.setImage(ImageLiteral.xmarkSymbol, for: .normal)
@@ -17,7 +19,8 @@ final class PracticeSongCardView: UIStackView {
     
     private let practiceSongName: InformationGuideLabel = InformationGuideLabel(guideText: "합주곡 제목", type: .required)
     
-    private let practiceSongTextField: BasicTextField = {
+    private lazy var practiceSongTextField: BasicTextField = {
+        $0.delegate = self
         $0.constraint(.widthAnchor,
                       constant: BasicComponentSize.width - 40)
         return $0
@@ -31,7 +34,8 @@ final class PracticeSongCardView: UIStackView {
     
     private let artistName: InformationGuideLabel = InformationGuideLabel(guideText: "아티스트", type: .required)
     
-    private let artistNameTextField: BasicTextField = {
+    private lazy var artistNameTextField: BasicTextField = {
+        $0.delegate = self
         $0.constraint(.widthAnchor,
                       constant: BasicComponentSize.width - 20)
         return $0
@@ -62,11 +66,19 @@ final class PracticeSongCardView: UIStackView {
         return $0
     }(UIStackView(arrangedSubviews: [linkLabel, linkDescription, linkTextField]))
     
+    // MARK: - init
+    
     init() {
         super.init(frame: .zero)
         setupLayout()
         attribute()
     }
+    
+    required init(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Method
     
     private func setupLayout() {
         self.addArrangedSubview(practiceSongNameVstack)
@@ -91,10 +103,6 @@ final class PracticeSongCardView: UIStackView {
         deleteButton.isHidden = true
     }
     
-    required init(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-    
     func getArtistName() -> String {
         return artistNameTextField.textField.text ?? ""
     }
@@ -110,3 +118,8 @@ final class PracticeSongCardView: UIStackView {
     }
 }
 
+extension PracticeSongCardView: BasicTextFieldDelegate {
+    func textFieldTextDidChange() {
+        NotificationCenter.default.post(name: Notification.Name.didPracticeCardViewTextFieldChange, object: nil)
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- closed #157 

## 배경
 밴드 생성 시 합주곡을 추가하기 위해서는 아래와 같은 카드 형태로 정보를 입력합니다. 이 UI를 구현했습니다.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/103009135/224059593-a8f364b7-7037-4b7a-94f1-424f0f852154.png">
</br>

## 테스트 방법
시작점을 아래와 같이 바꿔주시고 합주곡이 잘 추가되나 확인해주세요!

        window.rootViewController = UINavigationController(rootViewController: BandInformationSetViewController())


## 작업 내용

### 1️⃣ 합주곡 추가 레이아웃 구조 (AddPracticeSongViewController)

#### 이 VC 레이아웃은 MainScrollView아래 UIStackView로 ContentView를 잡은 구조입니다.

ContentView의 arrangedSubview는 PracticeSongCardView라는 UIStackView로, 유저가 합주곡 정보를 입력할 수 있는 3개의 텍스트필드가 들어있습니다.

테이블뷰나 콜렉션뷰를 사용하지 않고 스크롤뷰를 채택한 이유는 좀 더 빠른 개발을 위해서입니다.
이 VC의 UI에는 합주곡 추가 버튼이 항상 카드뷰의 하단에 배치되게 됩니다. 그럼 셀의 추가에 따라 이 버튼을 고정시키는 레이아웃을 구현하기가 어렵다고 판단했습니다. 또한 이 기능을 개발하는 당시 DiffableDataSource에 익숙치않은 상황이었습니다.

<img width="666" alt="image" src="https://user-images.githubusercontent.com/103009135/223443412-183862e2-e618-4125-8c03-576f0645da89.png">
위 그림에서 합주곡 추가 버튼이 보라색인데, 실제는 회색입니다. 예전에 미리 작성된 PR 내용을 가져와서 오류가 있네요 ㅎㅎ..
</br>

### 2️⃣ 추가 합주곡 전달 구조

이렇게 생성된 정보는 밴드정보 입력 VC로 클로저를 통해 전달됩니다.
이전의 노엘이 구현해준 CollectionViewCell의 UI 정보로 PracticeSongBoxView 를 구현했고 전달된 정보를 바탕으로 stackView를 configure하고, configured된 stackView를 삽입하는 구조입니다.

<img width="660" alt="image" src="https://user-images.githubusercontent.com/103009135/223445078-0337e522-ffa0-48dc-a02a-592ba57ed622.png">

https://github.com/extreme-rock/GetARock-iOS/blob/e210ea71582b6e6c2a8a5c12cc44a892c65e8f85/GetARock/GetARock/Screens/BandCreation/BandInformationSetFlow/BandInformationSetViewController.swift#L307-L318
</br>

### 3️⃣ 추가된 합주곡 및 합주곡 입력 카드 삭제 시 애니메이션 구현

https://user-images.githubusercontent.com/103009135/224062701-d70d426a-a98f-4eb5-94ca-04b67614f7b2.MP4

 UIStackView를 사용하면 View를 삭제할 때 removeFromSuperView를 사용하면 되기 때문에 삭제 코드가 간단하고 삭제에 따른 레이아웃 업데이트가 쉽습니다. 하지만 애니메이션이 없어 UX가 저해되었습니다. 그래서 최대한 이를 메꾸고자 UIView animation을 넣어보았습니다.
</br>

https://github.com/extreme-rock/GetARock-iOS/blob/e210ea71582b6e6c2a8a5c12cc44a892c65e8f85/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift#L186-L196
</br>


### 4️⃣ 필수 정보 누락에 따른 최종 추가 버튼 비활성화 기능
#### 1. 각 카드뷰의 텍스트필드는 텍스트가 변할 때마다 Notificaiton을 날립니다. 
https://github.com/extreme-rock/GetARock-iOS/blob/e210ea71582b6e6c2a8a5c12cc44a892c65e8f85/GetARock/GetARock/Global/UIComponent/BasicTextField.swift#L9-L11

https://github.com/extreme-rock/GetARock-iOS/blob/e210ea71582b6e6c2a8a5c12cc44a892c65e8f85/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/PracticeSongCardView.swift#L121-L125


2. AddPracticeSongViewController 에서 Notification을 수신합니다.
https://github.com/extreme-rock/GetARock-iOS/blob/e210ea71582b6e6c2a8a5c12cc44a892c65e8f85/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift#L156-L161


3. contentStackView의 하위뷰들 (PracticeCardView)에 접근해서 모든 필수정보가 입력되었는지 체크합니다. 그 체크 여부에 따라 버튼이 활성, 비활성화 됩니다.

https://github.com/extreme-rock/GetARock-iOS/blob/e210ea71582b6e6c2a8a5c12cc44a892c65e8f85/GetARock/GetARock/Screens/BandCreation/PracticeSongAddFlow/AddPracticeSongViewController.swift#L217-L229
</br>

### 🏃다음 PR 
####  이 PR이 승인되면 전달받은 정보들을 모두 수합해서 POST를 날리는 함수가 구현될 예정입니다. 
</br>

## 리뷰 노트
- UI는 작아보이지만 세부적인 내용이 많아 UI Testing에서 버그가 있을지 궁금합니다
- 불필요한 코드 및 부적절한 변수명
- 컨벤션 미준수 사항
- 로직 개선 가능 사항


<!-- 해당 PR 리뷰 과정에서 논의된 확정 사항을 develop 브랜치에 머지하기 전 정리합니다. -->
