### PR TITLE
[HotFix]  merge 후 BandInformationView에 변경된 타입으로 인해 발생한 오류를 해결합니다.

### DIFF
--- a/GetARock/GetARock/Global/UIComponent/SongListView.swift
+++ b/GetARock/GetARock/Global/UIComponent/SongListView.swift
@@ -94,7 +94,7 @@ extension SongListView: UICollectionViewDataSource {
             return UICollectionViewCell()
         }
         cell.configure(
-            data: songList?[indexPath.item],
+            data: songData?[indexPath.item],
             songListType: songListType,
             index: indexPath.item
         )

--- a/GetARock/GetARock/Screens/BandDetail/BandDetailViewController.swift
+++ b/GetARock/GetARock/Screens/BandDetail/BandDetailViewController.swift
@@ -12,7 +12,7 @@ final class BandDetailViewController: BaseViewController {
     // MARK: - Property
     
     //TODO: - 추후 상세페이지의 밴드 아이디를 지도로부터 받아와야함
-    private var bandID = "71"
+    private var bandID = "172"
     private var bandData = BandInformationVO(
         bandID: 0,
         name: "",

--- a/GetARock/GetARock/Screens/BandDetail/Component/BandInformationView.swift
+++ b/GetARock/GetARock/Screens/BandDetail/Component/BandInformationView.swift
@@ -73,7 +73,7 @@ final class BandInformationView: UIView {
     private lazy var bandSongListView: SongListView = {
         $0.constraint(.heightAnchor, constant: CGFloat((bandSong?.count ?? 0) * 80))
         return $0
-    }(SongListView(songListType: .detail, data: bandSong))
+    }(SongListView(songListType: .detail, songList: bandSong))
     
     private lazy var bandSongStackView: UIStackView = {
         $0.axis = .vertical
@@ -113,7 +113,7 @@ final class BandInformationView: UIView {
     )
     
     //TODO - : SNS의 데이터 구조 수정이 끝나면 전달 데이터 반영 필요
-    private lazy var bandSNSListView = SNSListStackView(data: SNS(youtube: nil, instagram: nil, soundCloud: nil))
+    private lazy var bandSNSListView = SNSListStackView(data: bandSNS ?? [])
     
     private lazy var bandSNSStackView: UIStackView = {
         $0.axis = .vertical
@@ -233,11 +233,11 @@ final class BandInformationView: UIView {
            }
        }
        
-       private func checkInstrumentImage(instrumentList: [InstrumentListVO]) -> InstrumentImageName {
+       private func checkInstrumentImage(instrumentList: [InstrumentListVO]) -> Instrument {
            let transformedMemberInstrument = instrumentList.map{ $0.name }
            
            if let mainInstrument = transformedMemberInstrument.first {
-               return InstrumentImageName(rawValue: mainInstrument) ?? .etc
+               return Instrument(rawValue: mainInstrument) ?? .etc
            }
            return .etc
        }

--- a/GetARock/GetARock/Screens/BandDetail/Component/BandInformationView.swift
+++ b/GetARock/GetARock/Screens/BandDetail/Component/BandInformationView.swift
@@ -112,7 +112,6 @@ final class BandInformationView: UIView {
         textColorInfo: .white
     )
     
-    //TODO - : SNS의 데이터 구조 수정이 끝나면 전달 데이터 반영 필요
     private lazy var bandSNSListView = SNSListStackView(data: bandSNS ?? [])
     
     private lazy var bandSNSStackView: UIStackView = {


### PR DESCRIPTION

## 관련 이슈

- closed #162 

## 배경
 merge 후 변경된 타입으로 인해 발생한 오류를 해결합니다.

## 작업 내용

`BandInformationView`의 view들에 들어가는 데이터의 타입이 변경되어 발생한 오류를 수정했습니다.


## 리뷰 노트
- merge 후 더이상 오류가 발생하지 않는지 확인부탁드립니다.
- SongListView에 Data가 들어가지 않는 이슈는 데이크 @ccdkk 의 PR에서 수정되어 합쳐질 예정입니다.
- InstrumentImageName 타입이 Instrument로 변경되면서 멤버의 Cell에 이미지가 들어가지않는 오류는 추후 제가 올릴 마이페이지 PR에서 수정되어 합쳐질 예정입니다.

