### PR TITLE
[Fix] 선택된 포지션이 0개 일 때 nextButton이 계속 enabled true이던 현상을 수정하였습니다.

### DIFF
--- a/GetARock/GetARock/Global/Supports/SceneDelegate.swift
+++ b/GetARock/GetARock/Global/Supports/SceneDelegate.swift
@@ -20,13 +20,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
         let window = UIWindow(windowScene: windowScene)
-        DispatchQueue.main.async {
-            if UserDefaultStorage.isLogin {
-                window.rootViewController = UINavigationController(rootViewController: MainMapViewController(isFromSignUp: false))
-            } else {
-                window.rootViewController = LandingViewController()
-            }
-        }
+        window.rootViewController = PositionSelectViewController()
+//        DispatchQueue.main.async {
+//            if UserDefaultStorage.isLogin {
+//                window.rootViewController = UINavigationController(rootViewController: MainMapViewController(isFromSignUp: false))
+//            } else {
+//                window.rootViewController = LandingViewController()
+//            }
+//        }
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/GetARock/GetARock/Global/Supports/SceneDelegate.swift
+++ b/GetARock/GetARock/Global/Supports/SceneDelegate.swift
@@ -20,14 +20,13 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
 
         let window = UIWindow(windowScene: windowScene)
-        window.rootViewController = PositionSelectViewController()
-//        DispatchQueue.main.async {
-//            if UserDefaultStorage.isLogin {
-//                window.rootViewController = UINavigationController(rootViewController: MainMapViewController(isFromSignUp: false))
-//            } else {
-//                window.rootViewController = LandingViewController()
-//            }
-//        }
+        DispatchQueue.main.async {
+            if UserDefaultStorage.isLogin {
+                window.rootViewController = UINavigationController(rootViewController: MainMapViewController(isFromSignUp: false))
+            } else {
+                window.rootViewController = LandingViewController()
+            }
+        }
         window.makeKeyAndVisible()
         self.window = window
     }

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -194,7 +194,7 @@ final class PositionCollectionView: UIView {
         }
     }
     
-    private func postToggleNextButtonEnbaled() {
+    private func postToggleNextButtonEnabled() {
         NotificationCenter.default.post(name: Notification.Name.toggleNextButtonEnbaled,
                                         object: nil)
     }
@@ -276,7 +276,7 @@ extension PositionCollectionView: UICollectionViewDelegate {
         if selectedCellCount == 1 {
             postDeselectAllPositionButtonHiddenToggle()
             markMainLabel(indexPath: indexPath)
-            postToggleNextButtonEnbaled()
+            postToggleNextButtonEnabled()
         }
         postDidTapPositionItem()
     }
@@ -313,7 +313,7 @@ extension PositionCollectionView: UICollectionViewDelegate {
             let selectedCellCount = collectionView.indexPathsForSelectedItems?.count
             if selectedCellCount == 0 {
                 postDeselectAllPositionButtonHiddenToggle()
-                postToggleNextButtonEnbaled()
+                postToggleNextButtonEnabled()
             }
             postDidTapPositionItem()
         }

--- a/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
+++ b/GetARock/GetARock/Global/UIComponent/PositionCollectionView.swift
@@ -313,6 +313,7 @@ extension PositionCollectionView: UICollectionViewDelegate {
             let selectedCellCount = collectionView.indexPathsForSelectedItems?.count
             if selectedCellCount == 0 {
                 postDeselectAllPositionButtonHiddenToggle()
+                postToggleNextButtonEnbaled()
             }
             postDidTapPositionItem()
         }


### PR DESCRIPTION
…#175)

<!-- 불필요한 항목은 삭제해주세요 -->


## 관련 이슈
- Close #175 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 배경

<!-- PR과 관련된 논의 쓰레드, 디자인 가이드, 관련 PR 링크 등을 적어주세요 -->

## 작업 내용
### 1️⃣ cell이 0개 이면 nextButton의 enabled 상태를 toggle해주는 함수를 추가하였습니다.
cell이 0개일 때 toggle해주는 함수가 없어서 발생한 현상으로, 해당 함수를 추가하여 해결하였습니다.
<!-- PR 작성 이유와 어떤 변경이 있었는지를 포함합니다. PR에 많은 변경이 있는 경우 추가되는 클래스들의 구조나 동작 등 자세하게 적는 경우도 있습니다 -->

## 리뷰 노트

<!-- 구현 시에 고민이었던 점들 혹은 특정 부분에 대한 의도가 있었다면 PR 리뷰의 이해를 돕기 위해 서술합니다. 또한 리뷰어에게 특정 부분에 대한 집중 혹은 코멘트를 요청하는 경우에 작성합니다. -->

## 테스트 방법

<!-- PR 리뷰어가 이 PR의 변경사항을 확인할 수 있는 방법을 서술합니다. 의도하는 테스트 결과도 서술하면 더 좋습니다 -->

## 스크린샷
![Simulator Screen Recording - iPhone 13 Pro - 2023-03-31 at 17 36 09](https://user-images.githubusercontent.com/91456952/229069978-bed26814-d69a-420e-aeb4-8a97709c7b4a.gif)
<!-- 화면 전환이나 인터랙션이 있는 경우 GIF를, 정적인 화면이라면 스크린샷을 첨부합니다. -->
<!-- <img width="" alt="" src=""> -->

<!--## 해당 PR 확정 사항-->

<!-- 해당 PR 리뷰 과정에서 논의된 확정 

사항을 develop 브랜치에 머지하기 전 정리합니다. -->
